### PR TITLE
fix(meta): adding pocket specific description field [FRONT-741]

### DIFF
--- a/src/components/social-meta-data/social-meta-data.js
+++ b/src/components/social-meta-data/social-meta-data.js
@@ -35,6 +35,9 @@ export function SocialMetaData({ url, title, description, image, type }) {
       {/*  Primary Meta Tags */}
       <meta name="description" content={description} {...testIdAttribute('meta-description')} />
 
+      {/*  Pocket Specific Tags */}
+      <meta name="x-pocket-override-excerpt" content={description} {...testIdAttribute('pkt-description')} />
+
       {/* Schema.org for Google */}
       <meta itemProp="name" content={title} {...testIdAttribute('itemprop-name')}/>
       <meta itemProp="description" content={description} {...testIdAttribute('itemprop-description')}/>

--- a/src/components/social-meta-data/social-meta-data.spec.js
+++ b/src/components/social-meta-data/social-meta-data.spec.js
@@ -16,6 +16,7 @@ const mockMetaImageData = {
 
 const expectedTags = [
   'meta-description',
+  'pkt-description',
   'itemprop-name',
   'itemprop-description',
   'twitter-card',


### PR DESCRIPTION
## Goal

The parser was having trouble capturing our syndicated excerpt. The request was to add a Pocket specific meta field.

## To Do:

- [x] Add meta field
- [x] Update tests

## Implementation Decisions

This work is duplicated to web-discover