### PR TITLE
fix(xss): wrap image code in updated dompurify [FRONT-748]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9180,9 +9180,9 @@
       }
     },
     "dompurify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.1.1.tgz",
-      "integrity": "sha512-NijiNVkS/OL8mdQL1hUbCD6uty/cgFpmNiuFxrmJ5YPH2cXrPKIewoixoji56rbZ6XBPmtM8GA8/sf9unlSuwg=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.0.tgz",
+      "integrity": "sha512-bqFOQ7XRmmozp0VsKdIEe8UwZYxj0yttz7l80GBtBqdVRY48cOpXH2J/CVO7AEkV51qY0EBVXfilec18mdmQ/w=="
     },
     "domutils": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "dayjs": "1.9.1",
     "detect-it": "3.0.6",
     "diff-match-patch": "1.0.5",
-    "dompurify": "2.1.1",
+    "dompurify": "2.2.0",
     "graphql-request": "3.1.0",
     "gsap": "3.5.1",
     "intersection-observer": "0.11.0",

--- a/src/components/reader/images.js
+++ b/src/components/reader/images.js
@@ -41,13 +41,13 @@ function buildImageMarkup(data) {
 
   return Promise.resolve({
     imageId: image_id,
-    markup: `
+    markup: DOMPurify.sanitize(`
         <figure>
           <img src='${imageSource}' alt='${cleanCaption}'/>
           ${captionMarkup}
           ${creditMarkup}
         </figure>
-      `
+      `)
   })
 }
 


### PR DESCRIPTION
## Goal

A security issue was raised in our bug bounty program where a malicious actor could steal users information via xss in image alt tags.

## To Do:

- [x] Update DOMPurify package
- [x] Wrap full image code block in DOMPurify

## Implementation Decisions

To verify, save the following article, and it should not throw an alert when viewing in app
http://s1a.pw/Moz.html

This work is duplicated to web-app-draft