### PR TITLE
fix(analytics): adding ids to reader links for snowplow tracking

### DIFF
--- a/src/components/reader/content.js
+++ b/src/components/reader/content.js
@@ -44,9 +44,10 @@ export const Content = ({
 
   const externalizeLinks = () => {
     const links = articleRef.current.querySelectorAll('a[href]')
-    links.forEach((link) => {
+    links.forEach((link, index) => {
       link.setAttribute('target', '_blank')
       link.setAttribute('rel', 'noopener noreferrer')
+      link.setAttribute('id', `reader.external-link.num-${index}`)
     })
   }
 

--- a/src/components/reader/header.js
+++ b/src/components/reader/header.js
@@ -141,7 +141,11 @@ export const ItemHeader = ({
       </div>
 
       <div className={pocketInfo}>
-        <a className={viewOriginal} href={open_url} target="_blank">
+        <a
+          id="reader.external-link.view-original"
+          className={viewOriginal}
+          href={open_url}
+          target="_blank">
           View Original {/*"reader.header.viewOriginal"*/}
         </a>
         {tags && (
@@ -150,7 +154,7 @@ export const ItemHeader = ({
               {tags.map((tag) => (
                 <li key={tag}>
                   <Link href={`/my-list/tags/${encodeURIComponent(tag)}`}>
-                    <a>
+                    <a id={`reader.tag.${tag}`}>
                       <Pill>{tag}</Pill>
                     </a>
                   </Link>


### PR DESCRIPTION
## Goal

Adding ids to the View Original link, each link in article, and the tags at the top