### PR TITLE
fix(tags): save on enter and no longer persisting incomplete tag value

### DIFF
--- a/src/components/tagging/tag.input.js
+++ b/src/components/tagging/tag.input.js
@@ -101,7 +101,13 @@ export class TagInput extends Component {
     if (event.keyCode === KEYS.ENTER) {
       event.preventDefault()
       event.stopPropagation()
-      if (this.props.value) this.props.addTag(`${this.props.value}`)
+
+      if (this.props.value) {
+        this.props.addTag(`${this.props.value}`)
+      }
+      else {
+        this.props.submitForm()
+      }
       return
     }
 

--- a/src/connectors/confirm-share/share-to-friend.js
+++ b/src/connectors/confirm-share/share-to-friend.js
@@ -99,7 +99,9 @@ export function ShareToFriend() {
 
   // Confirm share
   const sendConfirm = () => {
-    confirmShare(commentValue)
+    if (currentFriends.length !== 0) {
+      confirmShare(commentValue)
+    }
   }
 
   return (
@@ -129,6 +131,7 @@ export function ShareToFriend() {
             hasActiveTags={activeTags}
             deactivateTags={deactivateTags}
             handleRemoveAction={handleRemoveAction}
+            submitForm={sendConfirm}
             // Passed Props
             addTag={addTag}
             onFocus={onFocus}

--- a/src/connectors/confirm-tags/confirm-tags.js
+++ b/src/connectors/confirm-tags/confirm-tags.js
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Button } from '@pocket/web-ui'
 import { Modal, ModalBody, ModalFooter } from 'components/modal/modal'
 import { useDispatch, useSelector } from 'react-redux'
@@ -41,6 +41,10 @@ export function TaggingModal() {
   const [value, setValue] = useState('')
   const [hasError, setHasError] = useState(false)
   const [activeTags, setActiveTags] = useState([])
+
+  useEffect(() => {
+    setValue('')
+  }, [showModal])
 
   /**
    * Event Actions
@@ -133,6 +137,7 @@ export function TaggingModal() {
             hasActiveTags={activeTags}
             deactivateTags={deactivateTags}
             handleRemoveAction={handleRemoveAction}
+            submitForm={saveTags}
             // Passed Props
             addTag={addTag}
             onFocus={onFocus}


### PR DESCRIPTION
## Goal

Adding save on enter for tag.input. It now affects tag and share modal.

Value will no longer persist in tag modal when closed.