### PR TITLE
fix(layout): show actions at small list mode

### DIFF
--- a/src/components/items-layout/virtualized-list.js
+++ b/src/components/items-layout/virtualized-list.js
@@ -227,15 +227,13 @@ export const cardList = css`
       .excerpt {
         display: none;
       }
+
       .item-actions {
         width: 100%;
       }
 
       .actions button {
-        opacity: 0;
-        @media (hover: none) {
-          opacity: 1;
-        }
+        opacity: 1;
         &.active {
           opacity: 1;
         }


### PR DESCRIPTION
## Goal

Action buttons at small screens on mobile where being set to opacity: 0 incorrectly

## To Do:

- [x] Allow visible actions at mobile widths (without mobile devcies)
