### PR TITLE
fix(settings): stop propagation of font toggling

### DIFF
--- a/src/components/display-settings/display-settings.js
+++ b/src/components/display-settings/display-settings.js
@@ -108,7 +108,8 @@ export const DisplaySettings = ({
     setColumnWidth(parseInt(columnWidth) + 1)
   }
 
-  const toggleDisplayFonts = () => {
+  const toggleDisplayFonts = (e) => {
+    e.stopPropagation()
     setDisplayFonts(!displayFonts)
   }
   const updateFontFamily = (family) => {


### PR DESCRIPTION
## Goal

Clicking the Arrow in the modal was causing it to close.