### PR TITLE
refactor(reader): favor `get` over `getItem`

### DIFF
--- a/src/common/api/reader.js
+++ b/src/common/api/reader.js
@@ -6,9 +6,17 @@ import { request } from 'common/utilities/request/request'
  */
 export const getArticleFromId = (item_id) => {
   return request({
-    path: 'v3/getItem',
+    path: 'v3/get',
     params: {
-      item_id
+      tags: 1, //	int	1 to include Tags in Items
+      positions: 0, //	int	1 to include Positions in Items
+      authors: 1, //	int	1 to include Authors in Items
+      images: 1, //	int	1 to include Images in Items
+      videos: 1, //	int	1 to include Videos in Items
+      meta: 1, //	int	1 to include ItemMeta in Items
+      annotations: 1, //	int	1 to include Annotations in Items
+      attribution: 2, //	int	2 to include attributionTypes in the response as well as including ExtendAttribution in Items
+      item: item_id
     },
     auth: true
   })

--- a/src/containers/read/read.state.js
+++ b/src/containers/read/read.state.js
@@ -195,9 +195,9 @@ const getPremiumStatus = (state) => parseInt(state.user.premium_status, 10) === 
 function* articleItemRequest({ itemId }) {
   try {
     const response = yield getArticleFromId(itemId)
-    const item = response?.item[itemId]
+    const item = response?.list[itemId]
     const { resolved_url: url } = item
-    const derivedItems = deriveMyListItems(Object.values(response.item))
+    const derivedItems = deriveMyListItems([item])
     const itemsById = arrayToObject(derivedItems, 'item_id')
 
     if (item)


### PR DESCRIPTION
## Goal

When navigating to an item, upon returning to your list data (in this case image) was suddenly different.

## To Do:

- [x] Refactor reader call

## Implementation Decisions

So, this silliness is due to the fact that `getItem` does not include `top_image_url` so we would be getting the first image from the image array as opposed to our preferred image.  So this PR just swaps them until we get this sorted with the backend team.  It seems like (despite the documentation) `getItem` is out of date.