### PR TITLE
fix(snowplow): update do not track setting

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -47,7 +47,7 @@ export const SNOWPLOW_CONFIG = {
   appId: SNOWPLOW_APP_ID,
   platform: 'web',
   eventMethod: 'beacon',
-  respectDoNotTrack: false,
+  respectDoNotTrack: false, // temporary to determine impact
   contexts: { webPage: true, performanceTiming: true }
 }
 


### PR DESCRIPTION
## Goal

Temporary update to snowplow based on this conversation:
https://pocket.slack.com/archives/C01AJGJTJ58/p1612921516393700?thread_ts=1612228787.260300&cid=C01AJGJTJ58

### tldr;
Temporarily disabling DNT setting to see if drop-off in users when pushing web-client is due to this setting.