### PR TITLE
fix(analytics): fix outstanding anaytics events [FRONT-885]

### DIFF
--- a/src/components/reader/content.js
+++ b/src/components/reader/content.js
@@ -19,10 +19,12 @@ export const Content = ({
   annotations,
   annotationsBuilt,
   onHighlightHover,
+  externalLinkClick,
   ...args
 }) => {
   const articleRef = useRef(null)
   const [loaded, setLoaded] = useState(false)
+  const [linkList, setLinkList] = useState([])
 
   const processAnnotations = (annotations) => {
     removeAllHighlights()
@@ -42,19 +44,35 @@ export const Content = ({
     })
   }
 
+  const sendExternalLinkClick = (e) => {
+    const link = e.target.closest('a[href]')
+    const href = link.getAttribute('href')
+
+    externalLinkClick(href)
+  }
+
   const externalizeLinks = () => {
     const links = articleRef.current.querySelectorAll('a[href]')
     links.forEach((link, index) => {
       link.setAttribute('target', '_blank')
       link.setAttribute('rel', 'noopener noreferrer')
       link.setAttribute('id', `reader.external-link.num-${index}`)
+      link.addEventListener('click', sendExternalLinkClick)
     })
+
+    setLinkList(links)
   }
 
   useEffect(() => {
     if (content) externalizeLinks()
     if (images) loadParsedImages(images)
     if (videos) loadParsedVideos(videos)
+
+    return () => {
+      linkList.forEach((link, index) => {
+        link.removeEventListener('click', sendExternalLinkClick)
+      })
+    }
   }, [])
 
   useEffect(() => {

--- a/src/connectors/global-nav/global-nav-add.js
+++ b/src/connectors/global-nav/global-nav-add.js
@@ -8,7 +8,7 @@ function GlobalNavAddConnected({ onClose }) {
 
   const onSubmit = (url) => {
     // bool to denote save action, 0 is position which is required for engagement
-    dispatch(sendSaveEvent('global-nav.save', url))
+    dispatch(sendSaveEvent(url))
     dispatch(itemAddAction(url))
   }
   return <GlobalNavAdd onClose={onClose} onSubmit={onSubmit} />

--- a/src/connectors/global-nav/global-nav-search.js
+++ b/src/connectors/global-nav/global-nav-search.js
@@ -14,7 +14,7 @@ function GlobalNavSearchConnected({ onClose }) {
   const recentSearches = useSelector((state) => state?.userSearch?.recent ) //prettier-ignore
 
   const onSubmit = (searchTerm) => {
-    dispatch(sendSearchEvent('global-nav.search'))
+    dispatch(sendSearchEvent(searchTerm))
     dispatch(saveRecentSearch(searchTerm))
     router.push(`/my-list/search/?query=${escape(searchTerm)}`)
   }

--- a/src/connectors/global-nav/global-nav.analytics.js
+++ b/src/connectors/global-nav/global-nav.analytics.js
@@ -19,11 +19,12 @@ export const sendSaveEvent = (url) => (trackContentEngagement(
   'global-nav.save'
 ))
 
-export const sendSearchEvent = () => (trackEngagement(
+export const sendSearchEvent = (searchTerm) => (trackEngagement(
   ENGAGEMENT_TYPE_GENERAL,
   UI_COMPONENT_BUTTON,
   0, // position in list (zero since it's not in list)
-  'global-nav.search'
+  'global-nav.search.submit',
+  searchTerm
 ))
 
 export const sendBulkDeleteEvent = (items) => (trackContentEngagement(

--- a/src/connectors/snowplow/events/engagement.js
+++ b/src/connectors/snowplow/events/engagement.js
@@ -13,13 +13,16 @@ export const ENGAGEMENT_TYPE_REPORT = 'report'
  *          ENGAGEMENT_TYPE_SAVE,
  *          ENGAGEMENT_TYPE_REPORT
  *         )} - Indicates the type of engagement
- * @returns {{schema: *, data: {type: *}}}
+ * @returns {{schema: *, data: {type: *, value: *}}}
  */
-const createEngagementEvent = (type) => ({
-  schema: ENGAGEMENT_SCHEMA_URL,
-  data: {
-    type
+const createEngagementEvent = (type, value) => {
+  const data = { type }
+  if (value) data.value = value
+
+  return {
+    schema: ENGAGEMENT_SCHEMA_URL,
+    data
   }
-})
+}
 
 export default createEngagementEvent

--- a/src/connectors/snowplow/snowplow.state.js
+++ b/src/connectors/snowplow/snowplow.state.js
@@ -68,13 +68,14 @@ export const trackContentEngagement = (component, ui, position, items, identifie
     items
   }
 }
-export const trackEngagement = (component, ui, position, identifier) => {
+export const trackEngagement = (component, ui, position, identifier, value) => {
   return {
     type: SNOWPLOW_TRACK_ENGAGEMENT,
     component,
     ui,
     identifier,
-    position
+    position,
+    value
   }
 }
 
@@ -175,8 +176,8 @@ function* fireContentEngagmenet({ component, ui, identifier, position, items }) 
   yield sendCustomSnowplowEvent(engagementEvent, snowplowEntities)
 }
 
-function* fireEngagement({ component, ui, identifier, position }) {
-  const engagementEvent = createEngagementEvent(component)
+function* fireEngagement({ component, ui, identifier, position, value }) {
+  const engagementEvent = createEngagementEvent(component, value)
   const uiEntity = createUiEntity({
     type: ui,
     hierarchy: 0,

--- a/src/containers/read/read.analytics.js
+++ b/src/containers/read/read.analytics.js
@@ -1,10 +1,12 @@
 import { takeEvery, put } from 'redux-saga/effects'
 import { trackContentEngagement } from 'connectors/snowplow/snowplow.state'
+import { trackContentOpen } from 'connectors/snowplow/snowplow.state'
 import { trackImpression } from 'connectors/snowplow/snowplow.state'
 import { ENGAGEMENT_TYPE_GENERAL } from 'connectors/snowplow/events'
 import { ENGAGEMENT_TYPE_SAVE } from 'connectors/snowplow/events'
 import { IMPRESSION_COMPONENT_UI } from 'connectors/snowplow/events'
 import { IMPRESSION_REQUIREMENT_VIEWABLE } from 'connectors/snowplow/events'
+import { CONTENT_OPEN_TRIGGER_CLICK } from 'connectors/snowplow/events'
 import { UI_COMPONENT_BUTTON } from 'connectors/snowplow/entities'
 
 /** ACTIONS
@@ -76,4 +78,12 @@ export const sendImpression = (identifier) => (trackImpression(
   UI_COMPONENT_BUTTON,
   0,
   identifier
+))
+
+export const sendExternalLinkClick = (item, href) => (trackContentOpen(
+  href,
+  CONTENT_OPEN_TRIGGER_CLICK,
+  0, // position in list (zero since it's in reader)
+  item,
+  'reader.external-link'
 ))

--- a/src/containers/read/read.js
+++ b/src/containers/read/read.js
@@ -46,6 +46,7 @@ import { sendFavoriteEvent } from './read.analytics'
 import { sendAnnotationEvent } from './read.analytics'
 import { sendShareEvent } from './read.analytics'
 import { sendImpression } from './read.analytics'
+import { sendExternalLinkClick } from './read.analytics'
 
 export const COLUMN_WIDTH_RANGE = [531, 574, 632, 718, 826, 933, 1041]
 export const LINE_HEIGHT_RANGE = [1.2, 1.3, 1.4, 1.5, 1.65, 1.9, 2.5]
@@ -244,6 +245,10 @@ export default function Reader() {
     dispatch(favoriteAction([{ id }]))
   }
 
+  const externalLinkClick = (href) => {
+    dispatch(sendExternalLinkClick(articleData, href))
+  }
+
   return (
     <>
       <Head>
@@ -284,6 +289,7 @@ export default function Reader() {
           {articleContent ? (
             <Content
               {...contentData}
+              externalLinkClick={externalLinkClick}
               onMouseUp={toggleHighlight}
               onHighlightHover={toggleHighlightHover}
               annotationsBuilt={buildAnnotations}


### PR DESCRIPTION
## Goal

There were some broken analytics events. Auto link tracking wasn't working on the Reader page, so I needed to add a `content_open` event for these.

## To Do:

- [x] Add click events for links within the article
- [x] Send url on snowplow "add" event from global nav
- [x] Submit search term when searching in the global nav

