### PR TITLE
fix(reader): add state to item fetch

### DIFF
--- a/src/common/api/reader.js
+++ b/src/common/api/reader.js
@@ -17,7 +17,7 @@ export const getArticleFromId = (item_id) => {
       annotations: 1, //	int	1 to include Annotations in Items
       attribution: 2, //	int	2 to include attributionTypes in the response as well as including ExtendAttribution in Items
       item: item_id,
-      state: 'anyactive'
+      state: 'all'
     },
     auth: true
   })


### PR DESCRIPTION
## Goal

Fetch on reader item was failing if the item was archived.

## To Do:

- [x] Add `state: 'anyactive'`

## Discussions
- https://pocket.slack.com/archives/C01AJGJTJ58/p1613432435004800

## Implementation Decisions

This was omitted per the spec: https://github.com/Pocket/spec/blob/master/query/v3server/get.md

> Only return items of this status. Supported values: unread, read, anyactive when omitted, all unread and archived items are returned

@xXxXxXxXxXam, @kkyeboah Can you guys confirm the expected behavior here?  It is unclear what `anyactive` is and how it differs from `all unread and archived items`  

This now works, but I want to clear so as to better understand the implications of omission so we may update the spec accordingly.

_NOTE:  We are not using `getItem` because it is not update with our current `get` functionality (does not return top image and perhaps other discrepancies which was causing odd user experience with shifting data)
