### PR TITLE
fix(snowplow): verify user id exist before initializing

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -105,8 +105,6 @@ function PocketWebClient({ Component, pageProps, err }) {
     // loadOptinMonster()
   }, [user_status, sess_guid])
 
-  console.log(user_status)
-
   // Hydrate user features
   useEffect(() => {
     if (user_status === 'pending') return null


### PR DESCRIPTION
## Goal

We were initializing snowplow before a user_id existed. Now using that variable trigger the the effect, and verifying it exists.