### PR TITLE
fix(home): adding topics toggle styles [FRONT-893]

### DIFF
--- a/src/components/topic-selector/topic-selector.js
+++ b/src/components/topic-selector/topic-selector.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { css, cx } from 'linaria'
+import classNames from 'classnames'
 import { Pill } from '@pocket/web-ui'
+import { darkMode } from '@pocket/web-ui'
 
 export const pillboxStyle = css`
   ul {
@@ -14,13 +16,26 @@ export const pillboxStyle = css`
       margin: 0 var(--spacing025) var(--spacing075);
     }
   }
+
+  .active button {
+    border-color: var(--color-actionPrimaryHover);
+    background: var(--color-actionPrimarySubdued);
+    color: var(--color-actionPrimaryHover);
+    text-decoration: none;
+
+    ${darkMode} {
+      border-color: var(--color-textLinkHover);
+      color: var(--color-textLinkHover);
+      background: none;
+    }
+  }
 `
 
-const TopicPill = ({ topic, handleTopicClick }) => {
+const TopicPill = ({ topic, handleTopicClick, active }) => {
   const handleClick = () => handleTopicClick(topic)
 
   return (
-    <li>
+    <li className={classNames({ active })}>
       <Pill onClick={handleClick} data-cy="topic-pill">
         {topic.display_name}
       </Pill>
@@ -28,7 +43,7 @@ const TopicPill = ({ topic, handleTopicClick }) => {
   )
 }
 
-export const TopicSelector = ({ id, topics, handleTopicClick }) => {
+export const TopicSelector = ({ id, topics, topicSelections = [], handleTopicClick }) => {
   const topicsKeys = Object.keys(topics)
   const topicsArray = topicsKeys.map((key) => topics[key])
   // don't display promoted topics
@@ -41,6 +56,7 @@ export const TopicSelector = ({ id, topics, handleTopicClick }) => {
           <TopicPill
             handleTopicClick={handleTopicClick}
             topic={topic}
+            active={topicSelections.find(item => item.id === topic.id)}
             key={`topics-pillbox-${id}-${topic.topic}`}
           />
         ))}

--- a/src/containers/home/home.js
+++ b/src/containers/home/home.js
@@ -29,7 +29,13 @@ export default function Collection(props) {
   const topics = useSelector((state) => state.topicList?.topicsByName)
 
   // Actions
-  const handleTopicClick = (topic) => dispatch(setTopicSection(topic))
+  const handleTopicClick = (topic) => {
+    const topicAction = (topicSections.find(item => item.id === topic.id))
+      ? unsetTopicSection
+      : setTopicSection
+
+    dispatch(topicAction(topic))
+  }
 
   // Initialize data
   useEffect(() => {


### PR DESCRIPTION
## Goal

Updated the topics selector to allow for an active state

## To Do:

- [x] Add active styles

## Implementation Decisions
<img width="902" alt="image" src="https://user-images.githubusercontent.com/1273879/108410483-56ec4280-71dc-11eb-8dbb-bebf78899a44.png">

I didn't add the active styles to the Pill in `web-ui` because it seemed easier to customize here during active development