### PR TITLE
fix(snowplow): add client version

### DIFF
--- a/src/connectors/snowplow/entities/api-user.js
+++ b/src/connectors/snowplow/entities/api-user.js
@@ -1,7 +1,7 @@
 import { API_USER_ID } from 'common/constants'
 import { getSchemaUri } from 'common/api/snowplow-analytics'
 
-const RELEASE_VERSION = process.env.RELEASE_VERSION || '0.0.0'
+const RELEASE_VERSION = process.env.RELEASE_VERSION || 'v0.0.0'
 
 const API_USER_SCHEMA_URL = getSchemaUri('api_user', '1-0-1')
 


### PR DESCRIPTION
## Goal

Add an application version to snowplow calls to determine the version of the software errors may be emanating from

## To Do:

- [x] Bump the `api_user` entity to 1.0.1 to use the new `client_version` key
- [x] Add the `client_version` key with a base-line value

## Implementation Decisions

I set it up to be `1.0.0` for an initial implementation. The first goal is to confirm that we are still getting bad analytics events from the current version of the application. 