### PR TITLE
feat(api): adding web-client-api route to alb [FRONT-957]

### DIFF
--- a/.aws/production/load_balancers.tf
+++ b/.aws/production/load_balancers.tf
@@ -46,29 +46,23 @@ resource "aws_alb_listener_rule" "public_forward_101" {
 }
 
 # NOTE: Reserving this space for client side api routes
-# resource "aws_alb_listener_rule" "public_forward_102" {
-#   listener_arn = data.aws_alb_listener.web_client.arn
-#   action {
-#     type             = "forward"
-#     target_group_arn = aws_alb_target_group.public.arn
-#   }
+resource "aws_alb_listener_rule" "public_forward_102" {
+  listener_arn = data.aws_alb_listener.web_client.arn
+  action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.public.arn
+  }
 
-#   condition {
-#     host_header {
-#       values = [var.domain_name]
-#     }
-#   }
+  condition {
+    path_pattern {
+      values = [
+         "/web-client-api/*"
+      ]
+    }
+  }
 
-#   condition {
-#     path_pattern {
-#       values = [
-#          "/web-client-api/*"
-#       ]
-#     }
-#   }
-
-#   priority = 2102
-# }
+  priority = 2102
+}
 
 resource "aws_alb_listener_rule" "public_forward_103" {
   listener_arn = data.aws_alb_listener.web_client.arn


### PR DESCRIPTION
## Goal

This will allow us to use web-client-api routes on the live site.

## To Do:

- [x] Uncomment reserved space
- [x] Remove host name check since the proxy work has eliminated this requirement

