### PR TITLE
fix(video): direct embeds [FRONT-940]

### DIFF
--- a/src/components/video/video.js
+++ b/src/components/video/video.js
@@ -1,4 +1,3 @@
-import ReactPlayer from 'react-player'
 import { css } from 'linaria'
 
 //Padding Player ratio: 100 / (1280 / 720)
@@ -9,48 +8,33 @@ const videoWrapper = css`
     position: absolute;
     top: 0;
     left: 0;
+    bottom: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
     border-radius: 8px;
     overflow: hidden;
   }
 `
 
 export const Video = ({ videoData }) => {
-  // onReady = (a) => console.log('onReady', a)
-  // onStart = () => console.log('onStart')
-  // onRestart = () => console.log('onRestart')
-  // onPause = () => console.log('onPause')
-  // onBuffer = () => console.log('onBuffer')
-  // // onSeek = (a, b, c) => console.log('onSeek', a, b, c) Broke; investigate
-  // onEnded = () => console.log('onEnded')
-  // onError = (err) => console.log('onError', err)
-
-  // onProgress = ({ playedSeconds, played, loadedSeconds, loaded }) => console.log('onProgress')
-  // onDuration = (seconds) => console.log('onDuration', seconds)
-
-  const parsedVideoUrl = videoData.src
-    .replace('play_redirect?clip_id=', '') //youtube
-    .replace('&quality=hd', '') //vimeo
+  const id = videoData.vid
+  const type = videoData.type
+  const videoTypes = {
+    1: 'https://www.youtube-nocookie.com/embed/',
+    2: 'https://player.vimeo.com/video/',
+    3: 'https://player.vimeo.com/video/'
+  }
 
   return (
     <div className={videoWrapper}>
-      <ReactPlayer
-        controls
-        className={'player'}
-        url={parsedVideoUrl}
-        width="100%"
-        height="100%"
-        // onReady={this.onReady}
-        // onStart={this.onStart}
-        // onPlay={this.onRestart}
-        // onPause={this.onPause}
-        // onBuffer={this.onBuffer}
-        // onSeek={this.onSeek}
-        // onEnded={this.onEnded}
-        // onError={this.onError}
-        // progressInterval={5000} // calls onProgress in ms
-        // onProgress={this.onProgress}
-        // onDuration={this.onDuration}
-      />
+      <iframe
+        className="player"
+        title="pocket-video-frame"
+        src={`${videoTypes[type]}${id}?autoplay=1&dnt=1`}
+        frameBorder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; modestbranding; picture-in-picture"
+        allowFullScreen></iframe>
     </div>
   )
 }

--- a/src/containers/read/read.js
+++ b/src/containers/read/read.js
@@ -79,6 +79,11 @@ const articleWrapper = css`
     padding: 0 var(--spacing250);
     margin: var(--spacing250) auto;
   }
+
+  .is-video {
+    max-width: initial !important;
+    width: 80%;
+  }
 `
 
 const recsWrapper = css`
@@ -299,12 +304,14 @@ export default function Reader() {
           />
         </div>
         <article
-          className={classNames(ReaderFonts, GoogleFonts, 'reader')}
+          className={classNames(
+            ReaderFonts,
+            GoogleFonts,
+            'reader',
+            has_video === '2' && 'is-video'
+          )}
           style={customStyles}>
-          <ItemHeader
-            viewOriginalEvent={viewOriginalEvent}
-            {...headerData}
-          />
+          <ItemHeader viewOriginalEvent={viewOriginalEvent} {...headerData} />
           {articleContent ? (
             <Content
               {...contentData}


### PR DESCRIPTION
## Goal

Removes react player in favor of direct embeds.

## To Do:

- [x] Remove react player
- [x] Set up direct privacy embeds to vimeo/youtube
- [x] Adjust video size so it is not awful

## Implementation Decisions

There are a _many_ unknown downstream effects this will have surrounding all things that are non-standard...  I don't think we currently support non-standard video very well to begin with, so perhaps this will be a good signal as to how we can improve things.

![giphy-1](https://user-images.githubusercontent.com/16119672/110894371-a0482300-82ac-11eb-890c-5e5c3cca8a20.gif)

