### PR TITLE
fix(home): overflow on ff for card content [FRONT-985]

### DIFF
--- a/src/components/item-card/card-base.js
+++ b/src/components/item-card/card-base.js
@@ -58,6 +58,10 @@ export const cardStyles = css`
     border-radius: var(--size025);
   }
 
+  .content {
+    width: 100%;
+  }
+
   .title {
     --color-underliner: var(--color-canvas);
     font-family: 'Graphik Web';


### PR DESCRIPTION
## Goal

Fixes overflow on titles/excerpts in FF

## To Do:

- [x] Add explicit width to `content`

## Implementation Decisions

Looks like Firefox does not respect implicit grid width when it comes to overflow.