### PR TITLE
fix(sentry): remove unused integrations

### DIFF
--- a/src/common/setup/sentry.js
+++ b/src/common/setup/sentry.js
@@ -1,15 +1,8 @@
-import { Integrations } from '@sentry/tracing'
 const isDev = process.env.NODE_ENV !== 'production'
 
 export const sentrySettings = {
   dsn:
     'https://cc3aea2dd5ca4aefb5a18c671a229237@o28549.ingest.sentry.io/5436250',
-  integrations: [
-    new Integrations.BrowserTracing({
-      tracingOrigins: ['localhost.web.getpocket.com/', 'getpocket.com']
-    })
-  ],
   release: process.env.BUILD_ID,
-  tracesSampleRate: 0,
   environment: isDev ? 'Development' : 'Production'
 }


### PR DESCRIPTION
## Goal

Removing unused integrations that were obstructing reporting

## To Do:

- [x] Remove tracing integration

## Implementation Decisions

We had this set to `0` effectively removing the need for it.

![giphy-1](https://user-images.githubusercontent.com/16119672/111691737-d7a65a80-87eb-11eb-8900-835ebc1e7b3a.gif)
