### PR TITLE
fix(request): always use cors

### DIFF
--- a/src/common/utilities/request/request.js
+++ b/src/common/utilities/request/request.js
@@ -22,7 +22,7 @@ export const request = ({
   const apiToUse = api_url
 
   const corsParameters = {}
-  if (!ssr) corsParameters.enable_cors = 1
+  corsParameters.enable_cors = 1
 
   const queryParams = queryString.stringify({
     ...params,


### PR DESCRIPTION
## Goal

@bassrock Informs me that CORS also means `not oAuth` so for our purposes, we want it no matter the side the call is made from (server, client).

## To Do:

- [x] Submit to the madness

## Implementation Decisions

![giphy-1](https://user-images.githubusercontent.com/16119672/111714630-42b55880-880f-11eb-8861-af1cd187453a.gif)
