### PR TITLE
fix(request): ssr/client specific headers

### DIFF
--- a/src/common/utilities/request/request.js
+++ b/src/common/utilities/request/request.js
@@ -21,24 +21,33 @@ export const request = ({
   const credentials = 'include'
   const apiToUse = api_url
 
-  const corsParameters = {}
-  corsParameters.enable_cors = 1
-
+  /**
+   * Build a full url with properly appended query params
+   * @param enable_cors {num} This tells the web server to use cookies vs oAuth
+   * @param consumer_key {string} This is specific to the web-client
+   */
   const queryParams = queryString.stringify({
     ...params,
-    ...corsParameters,
+    enable_cors: 1,
     consumer_key: CONSUMER_KEY
   })
-
   const endpoint = `${apiToUse}/${path}?${queryParams}`
 
-  const ssrHeaders = cookie ? { Cookie: cookie, Origin: 'getpocket.com' } : {}
-  const headers = {
+  /**
+   * Set proper headers for the request
+   * @option clientHeaders - These make sure our response is returned in JSON
+   *
+   * @option ssrHeaders - These append a passed in cookie and origin since
+   * that  is not set automatically on the server
+   */
+  const clientHeaders = {
     'Content-Type': 'application/json',
-    'X-Accept': 'application/json; charset=UTF8',
-    ...ssrHeaders
+    'X-Accept': 'application/json; charset=UTF8'
   }
+  const ssrHeaders = { Cookie: cookie, Origin: 'https://getpocket.com' }
+  const headers = ssr ? ssrHeaders : clientHeaders
 
+  // On the server side we are logging this request out temporarily
   if (cookie) {
     Sentry.withScope((scope) => {
       scope.setTag('ssr', 'Request')


### PR DESCRIPTION
## Goal

Untangle some of the ssr requests we need to make rarely on the web-client (read: waypoint)


## To Do:

- [x] Set Origin more explicitly
- [x] Separate SSR headers and Client Headers
- [x] Clean up defunct code
- [x] Comment out what is going on - The follow up

## Implementation Decisions

Our api is finicky at times (read: always).  So this strips things down a bit, makes some comments and crosses all our fingers and toes.

If it goes well:
![giphy-1](https://user-images.githubusercontent.com/16119672/111819989-32988a00-889e-11eb-8a2e-45b0a9f4a3b6.gif)

If it goes poorly:

![giphy](https://user-images.githubusercontent.com/16119672/111819904-1bf23300-889e-11eb-8a4e-1480db6336cf.gif)
