### PR TITLE
fix(snowplow): link to old snowplow url in dev environments [FRONT-1082]

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -38,6 +38,11 @@ export const GREENHOUSE_JOBS_URL = 'https://boards-api.greenhouse.io/v1/boards/p
 // SNOWPLOW
 export const API_USER_ID = 89624 // Pocket backend identifier for an API user used in Snowplow analytic events
 export const SNOWPLOW_SCRIPT_URL = 'https://assets.getpocket.com/web-utilities/public/static/te.js'
+export const SNOWPLOW_SCRIPT_URL_DEV = 'https://assets.getpocket.com/web-utilities/public/static/sp.js'
+export const SNOWPLOW_SCRIPT = process.env.SHOW_DEV === 'included'
+  ? SNOWPLOW_SCRIPT_URL_DEV
+  : SNOWPLOW_SCRIPT_URL
+
 export const SNOWPLOW_COLLECTOR_URL = 'd.getpocket.com'
 export const SNOWPLOW_COLLECTOR_URL_DEV = 'com-getpocket-prod1.mini.snplow.net'
 export const SNOWPLOW_COLLECTOR = process.env.SHOW_DEV === 'included'

--- a/src/common/setup/snowplow.js
+++ b/src/common/setup/snowplow.js
@@ -4,7 +4,7 @@ import { SNOWPLOW_HEARTBEAT_INTERVAL } from 'common/constants'
 import { SNOWPLOW_CONFIG } from 'common/constants'
 import { createUserEntity, apiUserEntity } from 'connectors/snowplow/entities'
 import { injectInlineScript } from 'common/utilities/inject-script'
-import { SNOWPLOW_SCRIPT_URL } from 'common/constants'
+import { SNOWPLOW_SCRIPT } from 'common/constants'
 
 /**
  * Load the Snowplow script onto the page. Should be called within the document <head>.
@@ -16,7 +16,7 @@ function loadSnowplow(snowplowInstanceName) {
   injectInlineScript(`;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
     p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
     };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
-    n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","${SNOWPLOW_SCRIPT_URL}","${snowplowInstanceName}"));`)
+    n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","${SNOWPLOW_SCRIPT}","${snowplowInstanceName}"));`)
 }
 
 export function initializeSnowplow(user_id, sess_guid) {


### PR DESCRIPTION
## Goal

Addressing an issue called out by Kenny this morning.

In order for events to go to Snowplow Mini in our dev environments, we need to link to the old snowplow file. (good thing we kept it around!)