### PR TITLE
build(ci): pass arguments correctly to ecr orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 # Orbs: Pre-configured bundled functionality
 orbs:
   aws-cli: circleci/aws-cli@2.0.0
-  aws-ecr: circleci/aws-ecr@7.0.0
+  aws-ecr: circleci/aws-ecr@6.1.0
   assume-role: lbh-hackit/aws_assume_role@0.1.0
   cypress: cypress-io/cypress@1
   slack: circleci/slack@3.4.0
@@ -182,9 +182,7 @@ jobs:
           access_key_id: OLD_AWS_ACCESS_KEY_ID
           secret_access_key: OLD_AWS_SECRET_ACCESS_KEY
           account: $ACCOUNT_ID_PROD
-      - aws-ecr/ecr-login:
-          aws-access-key-id: OLD_AWS_ACCESS_KEY_ID
-          aws-secret-access-key: OLD_AWS_SECRET_ACCESS_KEY
+      - aws-ecr/ecr-login
       - run:
           name: Tag As latest
           command: |
@@ -247,9 +245,7 @@ jobs:
           command: |
             echo 'export AWS_ECR_ACCOUNT_URL="${AWS_ECR_ACCOUNT_DEV_URL}"' >> $BASH_ENV
             docker tag ${AWS_ECR_ACCOUNT_PROD_URL}/${MAIN_IMAGE_NAME}:$CIRCLE_SHA1 ${AWS_ECR_ACCOUNT_DEV_URL}/${MAIN_IMAGE_NAME}:$CIRCLE_SHA1
-      - aws-ecr/ecr-login:
-          aws-access-key-id: OLD_AWS_ACCESS_KEY_ID
-          aws-secret-access-key: OLD_AWS_SECRET_ACCESS_KEY
+      - aws-ecr/ecr-login
       - aws-ecr/push-image:
           repo: $MAIN_IMAGE_NAME
           tag: $CIRCLE_SHA1
@@ -262,6 +258,7 @@ jobs:
     docker:
       - image: circleci/python # for aws cli without fluff
     steps:
+      - checkout
       - aws-cli/install
       - assume-role/assume_role:
           role: $ROLE_NAME


### PR DESCRIPTION
## Goal

`circleci/aws-ecr@7.0.0` orb is inconsistent with how env arguments are passed in. It also does not use the assumed role, imagine that.