### PR TITLE
fix(home): have topics selector key of slug instead of id [FRONT-1129]

### DIFF
--- a/src/containers/home/home.state.js
+++ b/src/containers/home/home.state.js
@@ -83,7 +83,7 @@ export const homeReducers = (state = initialState, action) => {
     case HOME_TOPIC_SECTION_UNSET: {
       const { topic } = action
       const filteredTopicSections = state.topicSections.filter(
-        (section) => section.id !== topic.id
+        (section) => section.topic_slug !== topic.topic_slug
       )
       return { ...state, topicSections: filteredTopicSections }
     }

--- a/src/containers/home/topicSelector.js
+++ b/src/containers/home/topicSelector.js
@@ -78,7 +78,7 @@ export const TopicSelector = () => {
   const journeySubTitle = journeySubTitles[Math.min(topicSections?.length, Math.max(0, 1))]
 
   const handleTopicClick = (topic) => {
-    const topicAction = topicSections.find((item) => item.id === topic.id)
+    const topicAction = topicSections.find((item) => item.topic_slug === topic.topic_slug)
       ? unsetTopicSection
       : setTopicSection
 
@@ -95,7 +95,7 @@ export const TopicSelector = () => {
             <TopicPill
               handleTopicClick={handleTopicClick}
               topic={topic}
-              active={topicSections.find((item) => item.id === topic.id) || false } //prettier-ignore
+              active={topicSections.find((item) => item.topic_slug === topic.topic_slug) || false } //prettier-ignore
               key={`topics-pillbox-${topic.topic}`}
             />
           ))}


### PR DESCRIPTION
## Goal

Turns out the static ID we were using to key from was not so static. This could lead to duplicates in the sidebar and for saved topics to unselect. Updating to use the slug.

## To Do:

- [x] update topic selector to key of slug as the id may change

