### PR TITLE
fix(tags): listState should be set to dirty when successfully tagging items [FRONT-1034]

### DIFF
--- a/src/containers/my-list/my-list.state.js
+++ b/src/containers/my-list/my-list.state.js
@@ -33,6 +33,7 @@ import { ITEMS_DELETE_SEND } from 'actions'
 import { ITEMS_DELETE_SUCCESS } from 'actions'
 import { ITEMS_UNFAVORITE_REQUEST } from 'actions'
 import { ITEMS_ADD_SUCCESS } from 'actions'
+import { ITEMS_TAG_SUCCESS } from 'actions'
 
 import { MYLIST_SEARCH_REQUEST } from 'actions'
 import { MYLIST_SEARCH_CLEAR } from 'actions'
@@ -221,6 +222,7 @@ export const myListReducers = (state = initialState, action) => {
       return { ...state, ...hydrated }
     }
 
+    case ITEMS_TAG_SUCCESS:
     case ITEMS_ADD_SUCCESS: {
       return { ...state, listState: 'dirty' }
     }


### PR DESCRIPTION
## Goal

When tagging items, My List was not updating. This sets `listState` to `dirty` so we update my list data when a user has updated tags.

[FRONT-1034](https://getpocket.atlassian.net/browse/FRONT-1034)

## To Do:

- [x] Set `listData` to `dirty` on `ITEMS_TAG_SUCCESS`

## Implementation Decisions

Nada