### PR TITLE
fix(feature flags): override more aggressively

### DIFF
--- a/src/connectors/feature-flags/feature-flags.state.js
+++ b/src/connectors/feature-flags/feature-flags.state.js
@@ -123,10 +123,7 @@ export function checkOverrides(assignments) {
   // If we are assigned, active, and not in control for a test that has an override
   // add the override name to this array
   const overrides = assignments
-    .filter(
-      (test) =>
-        test?.assigned && test?.active && test?.variant !== 'control' && test.payload?.override
-    )
+    .filter((test) => test?.assigned && test.payload?.override)
     .map((test) => test.payload?.override)
 
   // Loop through the assignments and if the override test name exists, make sure


### PR DESCRIPTION
## Goal

We don't want to muddy control if a user is assigned to a test that should take precedence.

## To Do:

- [x] make override more aggressive
