### PR TITLE
fix(publisher image): add alt text for publisher image on syndicated articles [FRONT-1060]

### DIFF
--- a/src/components/article/publisher-attribution.js
+++ b/src/components/article/publisher-attribution.js
@@ -82,7 +82,7 @@ function PublisherInfo({ logoWide, publishedAt, name }) {
     <React.Fragment>
       <hr />
       {logoWide ? (
-        <img src={logoWide.url} data-cy="publisher-img" />
+        <img src={logoWide.url} data-cy="publisher-img" alt={`Logo for ${name}`} />
       ) : null}
       <p>
         This post originally appeared on {name} and was published{' '}


### PR DESCRIPTION
## Goal

Add alt text for publisher image
[FRONT-1060](https://getpocket.atlassian.net/browse/FRONT-1060)

## To Do:

- [x] Add alt text for publisher image


<img width="726" alt="Screen Shot 2021-05-12 at 12 40 10 PM" src="https://user-images.githubusercontent.com/2893463/118020615-e4dd5280-b31f-11eb-8683-ca724d5fd08b.png">

