### PR TITLE
build(ci): remove ‘latest’ tag for compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -591,7 +591,7 @@ workflows:
           context: pocket
           name: build_docker
           environment: 'Dev'
-          tag: $CIRCLE_SHA1
+          tag: latest,$CIRCLE_SHA1
           # dev-app is based on how its created in shared infrastructure
           # https://github.com/Pocket/shared-infrastructure
           repo_name: webclient-dev-app 
@@ -607,7 +607,7 @@ workflows:
           context: pocket
           name: build_docker_dev
           environment: 'Dev'
-          tag: $CIRCLE_SHA1
+          tag: latest,$CIRCLE_SHA1
           repo_name: webclient-dev-app
           ecr_url: 410318598490.dkr.ecr.us-east-1.amazonaws.com
           push: true
@@ -648,7 +648,7 @@ workflows:
           context: pocket
           name: build_docker_prod
           environment: 'Prod'
-          tag: $CIRCLE_SHA1
+          tag: latest,$CIRCLE_SHA1
           repo_name: webclient-prod-app
           ecr_url: 996905175585.dkr.ecr.us-east-1.amazonaws.com
           push: true


### PR DESCRIPTION
## Goal

Old ECR orb may not properly support multiple tags ... however it is required for our legacy, so we can put this back in future.

## To Do:

- [x] remove 'latest' from tag list
