### PR TITLE
feat(discover): add locale based feeds (de) [FRONT-1133, FRONT-1132]

### DIFF
--- a/src/common/api/discover.js
+++ b/src/common/api/discover.js
@@ -5,10 +5,11 @@ import { recommendationsFromSlate } from 'common/utilities'
 
 import getSlateLineup from 'common/api/graphql-queries/get-slate-lineup'
 
-export async function getDiscoverFeed(recommendationCount = 30) {
+export async function getDiscoverFeed({ recommendationCount = 30, locale }) {
+  const id = getLocaleId(locale)
   return requestGQL({
     query: getSlateLineup,
-    variables: { id: TOPIC_IDS['explore'].id, recommendationCount }
+    variables: { id, recommendationCount }
   })
     .then(processSlates)
     .catch((error) => console.error(error))
@@ -17,8 +18,20 @@ export async function getDiscoverFeed(recommendationCount = 30) {
 function processSlates(response) {
   const slateLineup = getRecIds(response?.data?.getSlateLineup)
   const slates = response?.data?.getSlateLineup?.slates || []
-  const top = recommendationsFromSlate(slates[0], slateLineup)
-  const bottom = recommendationsFromSlate(slates[1], slateLineup)
+  const top = slates[0] ? recommendationsFromSlate(slates[0], slateLineup) : []
+  const bottom = slates[1] ? recommendationsFromSlate(slates[1], slateLineup) : []
 
   return [...top, ...bottom]
+}
+
+const getLocaleId = function (locale) {
+  switch (locale) {
+    case 'de': {
+      return TOPIC_IDS['explore']['de'].id
+    }
+
+    default: {
+      return TOPIC_IDS['explore']['en'].id
+    }
+  }
 }

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -226,6 +226,11 @@ export const TOPIC_IDS = {
     id: '2a817ad0-cbba-4330-9559-291468145588'
   },
   explore: {
-    id: '9c3018a8-8aa9-4f91-81e9-ebcd95fc82da'
+    de: {
+      id: '507d215c-4776-4f8e-af49-2ed6f3309aff'
+    },
+    en: {
+      id: '9c3018a8-8aa9-4f91-81e9-ebcd95fc82da'
+    }
   }
 }

--- a/src/containers/discover/discover.js
+++ b/src/containers/discover/discover.js
@@ -33,7 +33,7 @@ import { CallOutBrand } from 'components/call-out/call-out-brand'
 import { CallOutStartLibraryExplore } from 'components/call-out/call-out-start-library'
 import { CallOutPocketHitsSignup } from 'components/call-out/call-out-pocket-hits'
 
-export default function Discover({ url }) {
+export default function Discover({ url, locale }) {
   useEffect(trackPageView, [])
 
   // Select items
@@ -42,6 +42,7 @@ export default function Discover({ url }) {
   const topics = useSelector((state) => state.topicList?.topicsByName)
   const userStatus = useSelector((state) => state.user.user_status)
   const shouldRender = userStatus !== 'pending'
+  const showTopics = locale === 'en'
 
   const metaData = {
     description: 'Discover fascinating stories from all across the web with Pocket.',
@@ -64,7 +65,7 @@ export default function Discover({ url }) {
       {/* Top Lockup (center)*/}
       <Lockup items={items} offset={0} heroPosition="center" ItemCard={ItemCard} />
 
-      <CardTopicsNav topics={topics} track={trackTopicClick} />
+      {showTopics ? <CardTopicsNav topics={topics} track={trackTopicClick} /> : null}
 
       {/* Pocket Brand Messaging */}
       <CalloutTop shouldRender={shouldRender} isAuthenticated={isAuthenticated} />
@@ -78,9 +79,17 @@ export default function Discover({ url }) {
 
       <CalloutBottom shouldRender={shouldRender} isAuthenticated={isAuthenticated} />
 
-      <OffsetList items={items} offset={15} cardShape="wide" ItemCard={ItemCard} border={true} />
+      <OffsetList
+        items={items}
+        offset={15}
+        cardShape="wide"
+        ItemCard={ItemCard}
+        border={showTopics}
+      />
 
-      <CardTopicsNav topics={topics} track={trackTopicClick} className="no-border" />
+      {showTopics ? (
+        <CardTopicsNav topics={topics} track={trackTopicClick} className="no-border" />
+      ) : null}
 
       <ReportFeedbackModal />
     </Layout>

--- a/src/containers/discover/discover.state.js
+++ b/src/containers/discover/discover.state.js
@@ -97,9 +97,9 @@ function* discoverUnSaveRequest(action) {
  * Make and async request for a Pocket v3 feed and return best data
  * @return items {array} An array of derived items
  */
-export async function fetchDiscoverData() {
+export async function fetchDiscoverData({ locale }) {
   try {
-    const response = await getDiscoverFeed()
+    const response = await getDiscoverFeed({ locale })
     const derivedItems = await deriveDiscoverItems(response)
 
     const items = derivedItems.map((item) => item.item_id)

--- a/src/pages/discover/index.js
+++ b/src/pages/discover/index.js
@@ -15,28 +15,26 @@ import { LOCALE_COMMON } from 'common/constants'
  * until they are resolved, which is fine if we need the data for
  * SEO/Crawlers
   --------------------------------------------------------------- */
-export const getStaticProps = wrapper.getStaticProps(
-  async ({ store, locale }) => {
-    const { dispatch } = store
+export const getStaticProps = wrapper.getStaticProps(async ({ store, locale }) => {
+  const { dispatch } = store
 
-    // Hydrating initial state with an async request. This will block the
-    // page from loading. Do this for SEO/crawler purposes
-    const response = await fetchDiscoverData(true)
-    const { items, itemsById } = response
-    const topicsByName = await fetchTopicList(true)
+  // Hydrating initial state with an async request. This will block the
+  // page from loading. Do this for SEO/crawler purposes
+  const response = await fetchDiscoverData({ locale })
+  const { items, itemsById } = response
+  const topicsByName = await fetchTopicList(true)
 
-    // Since ssr will not wait for side effects to resolve this dispatch
-    // needs to be pure as well.
-    dispatch(hydrateDiscover({ items }))
-    dispatch(hydrateItems(itemsById))
-    dispatch(hydrateTopicList({ topicsByName }))
+  // Since ssr will not wait for side effects to resolve this dispatch
+  // needs to be pure as well.
+  dispatch(hydrateDiscover({ items }))
+  dispatch(hydrateItems(itemsById))
+  dispatch(hydrateTopicList({ topicsByName }))
 
-    // Revalidate means this can be regenerated once every X seconds
-    return {
-      props: { ...(await serverSideTranslations(locale, [...LOCALE_COMMON])) },
-      revalidate: 60
-    }
+  // Revalidate means this can be regenerated once every X seconds
+  return {
+    props: { ...(await serverSideTranslations(locale, [...LOCALE_COMMON])) },
+    revalidate: 60
   }
-)
+})
 
 export default Discover


### PR DESCRIPTION


## Goal

This allows us to define locale based explore feeds. Currently we only have `de` and `en` (the default)

## To Do:

- [x] Allow for grabbing id based on locale
- [x] Show topics based on locale

![Screen Shot 2021-05-17 at 9 42 19 PM](https://user-images.githubusercontent.com/16119672/118591275-c67cba00-b758-11eb-814f-d3f435e1e38d.png)