### PR TITLE
fix(package): bump @pocket/web-ui to 2.35.1 to grab new footer link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3104,9 +3104,9 @@
       "integrity": "sha512-sWlDmfMe/HT6YiVChkUi8Mx3T8+X9YxVGAKXdck5GGuspCG/TA9N8JVCdVPbN2P2KDubTTnR3fvj2gP/5chdgA=="
     },
     "@pocket/web-ui": {
-      "version": "2.35.0",
-      "resolved": "https://npm.pkg.github.com/download/@pocket/web-ui/2.35.0/bf64acbe62259cc0a4f619ec037c5e400e1cc9117bb25bee6196252eaa17f255",
-      "integrity": "sha512-Qrhzs6TSOIz3jD7fsEDC8ubnXHtLMSaSbcHhBvYTusJcRY+Zx2TMzMsfY0nLxP5CoMFbbJBH9Gn1y7CIpY4v8Q==",
+      "version": "2.35.1",
+      "resolved": "https://npm.pkg.github.com/download/@pocket/web-ui/2.35.1/95b0a5e178825032638f2c8b6949d2531eb2b16d2f529d7813ccccfd507d07d0",
+      "integrity": "sha512-1APy5YV6cnmWN5B8gHBWOMiI5ZlUBiFV/kJUTBu+QYvtHBAyN03KJ/SH1uEyHwWeQH3Gq9qtGJ7zICU25C3XNw==",
       "requires": {
         "@babel/node": "7.8.7",
         "@popperjs/core": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   "dependencies": {
     "@n8tb1t/use-scroll-position": "2.0.3",
     "@pocket/web-localization": "0.9.2",
-    "@pocket/web-ui": "2.35.0",
+    "@pocket/web-ui": "2.35.1",
     "@pocket/web-utilities": "1.16.4",
     "@sentry/node": "6.4.0",
     "@sentry/react": "6.4.0",


### PR DESCRIPTION
## Goal

- bump @pocket/web-ui to 2.35.1 to grab new footer link

## To Do:

- [x] bump @pocket/web-ui to 2.35.1 to grab new footer link


![giphy](https://user-images.githubusercontent.com/2893463/118730800-cbe01000-b7fd-11eb-9577-da29a8e3bf5d.gif)
