### PR TITLE
fix(discover): don’t allow read now for now

### DIFF
--- a/src/connectors/item-card/discover/card-actions.js
+++ b/src/connectors/item-card/discover/card-actions.js
@@ -38,7 +38,7 @@ export function ActionsDiscover({ id, position }) {
   return item ? (
     <div className={`${itemActionStyle} actions`}>
       <SaveToPocket
-        allowRead={true}
+        allowRead={false}
         url={url}
         onOpen={onOpen}
         openExternal={openExternal}


### PR DESCRIPTION
## Goal

Read now button is awesome ... but flawed due to how backend provides some data to us.  We can sort it, but for now parity is just `saved`

## To Do:

- [x] turn off read now in discover

## Implementation Decisions

Temporary goodbye to `read now` in discover

![giphy-1](https://user-images.githubusercontent.com/16119672/119021216-0360d080-b954-11eb-82a2-b10972fa69e8.gif)
