### PR TITLE
fix(explore): add rewrite for topic pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,7 @@ module.exports = withPlugins([withCSS], {
     return [
       { source: '/explore', destination: '/discover' },
       { source: '/explore/item/:slug', destination: '/discover/item/:slug' },
+      { source: '/explore/:slug', destination: '/discover/:slug' },
       { source: '/web-client-health', destination: '/health' },
       { source: '/web-client-api/:path*', destination: '/api/:path*' }
     ]


### PR DESCRIPTION
## Goal

This will add proper rewrites for discover->explore ... so `explore/<topic>` will work as expected.

## To Do:

- [x] Add top level slug rewrite for discover->explore

## Implementation Decisions

![giphy](https://user-images.githubusercontent.com/16119672/119033753-72452600-b962-11eb-8eda-ae4671032d91.gif)
