### PR TITLE
fix(syndicated): video sizing

### DIFF
--- a/src/components/content-parsed/content-parsed.js
+++ b/src/components/content-parsed/content-parsed.js
@@ -113,6 +113,25 @@ const contentWrapper = css`
     font-size: var(--fontSize125);
   }
 
+  .RIL_video {
+    position: relative;
+    padding-top: 56.25%;
+    margin-bottom: 2rem;
+
+    .player,
+    object {
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
+      width: 100%;
+      height: 100%;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+  }
+
   .description,
   .ril_caption_content,
   .credit_content,


### PR DESCRIPTION
## Goal

Update videos so they are not out of size with the content.

## To Do:

- [x] Add some CSS for parsed content with `RIL_video`

## Implementation Decisions

This matches the fix we put in for videos that you have saved.

<img width="782" alt="Screen Shot 2021-05-25 at 12 33 21 PM" src="https://user-images.githubusercontent.com/16119672/119567518-47dbda00-bd61-11eb-8467-b475a59874a6.png">

VS

<img width="880" alt="Screen Shot 2021-05-25 at 12 35 52 PM" src="https://user-images.githubusercontent.com/16119672/119567548-4ca08e00-bd61-11eb-8885-e175005a167c.png">
