### PR TITLE
fix(content actions): specificity on svg height

### DIFF
--- a/src/components/content-actions/article-actions.js
+++ b/src/components/content-actions/article-actions.js
@@ -29,6 +29,9 @@ const shareContainer = css`
       align-items: center;
     }
     & > div {
+      svg {
+        height: 24px;
+      }
       margin-bottom: 1rem;
       ${breakpointMediumTablet} {
         font-size: 1.6rem;


### PR DESCRIPTION
## Goal

The item actions on syndicated/collections are not always getting picked up in the correct order. 

## To Do:

- [x] Add specific height for SVG icons
