### PR TITLE
fix(analytics): update collections events to pass in custom items

### DIFF
--- a/src/connectors/item-card/collection/story-actions.js
+++ b/src/connectors/item-card/collection/story-actions.js
@@ -20,11 +20,11 @@ export function ActionsCollection({ id, position }) {
   // Prep save action
   const onSave = () => {
     dispatch(saveItem(id, url))
-    dispatch(trackItemSave(position, item, 'collection.save'))
+    dispatch(trackItemSave(position, { url }, 'collection.save'))
   }
 
   // Open action
-  const onOpen = () => dispatch(trackItemOpen(position, item, 'collection.open', url))
+  const onOpen = () => dispatch(trackItemOpen(position, { url }, 'collection.open', url))
 
   return item ? (
     <div className={`${itemActionStyle} actions`}>

--- a/src/connectors/item-card/collection/story-card.js
+++ b/src/connectors/item-card/collection/story-card.js
@@ -26,7 +26,7 @@ export function ItemCard({ id, position }) {
    */
   const onImpression = () => dispatch(trackItemImpression(position, item, 'collection.impression'))
   const onItemInView = (inView) => (!impressionFired && inView ? onImpression() : null)
-  const onOpen = () => dispatch(trackItemOpen(position, item, 'collection.open'))
+  const onOpen = () => dispatch(trackItemOpen(position, { url }, 'collection.open', url))
 
   return (
     <Card

--- a/src/connectors/snowplow/entities/content.js
+++ b/src/connectors/snowplow/entities/content.js
@@ -10,8 +10,8 @@ export const CONTENT_SCHEMA_URL = getSchemaUri('content')
  * A unique piece of content (item) within Pocket, usually represented by a URL. Should be included in all events that relate to content (primarily recommendation card impressions/engagements and item page impressions/engagements).
  *
  * @param url {string} - The full URL of the content. @required
- * @param itemId {string} - The backend identifier for a URL. @optional
- * @returns {{schema: *, data: {url: string, ?item_id: string}}}
+ * @param itemId {int} - The backend identifier for a URL. @optional
+ * @returns {{schema: *, data: {url: string, ?item_id: int}}}
  */
 const createContentEntity = (url, itemId) => {
   const data = { url }


### PR DESCRIPTION
## Goal

Snowplow was pulling what we have as `item_id` into the content entity. Since this isn't a true `item_id`, but an `externalId`, this was causing issues. Instead we need to pass in just the `url`

## To Do:

- [x] Update collections events

## Implementation Decisions

I dunno, I'm so tired of these things

![tired](https://user-images.githubusercontent.com/1273879/120696312-3f6e5800-c461-11eb-9abb-5aecd65c567f.gif)
