### PR TITLE
fix(ga): track google analytics pageview with router.aspath

### DIFF
--- a/src/connectors/one-trust/one-trust.js
+++ b/src/connectors/one-trust/one-trust.js
@@ -21,7 +21,7 @@ export function PostTrustInit() {
   const dispatch = useDispatch()
   const router = useRouter()
 
-  const path = router.pathname
+  const path = router.asPath
   const [analyticsInit, analyticsInitSet] = useState(false)
   const { user_status, user_id, sess_guid } = useSelector((state) => state.user)
   const oneTrustReady = useSelector((state) => state.oneTrust?.trustReady)


### PR DESCRIPTION
## Goal

All Google analytics pageviews for our topics pages are being tracked to `getpocket.com/discover/[slug]`. This is due to us using `router.pathName` for this value which uses the actual folder structure instead of what it actually resolves to. Updating to `router.asPath` for this value fixes the issue.

## To Do:

- [x] `pathName` => `asPath`

## Implementation Decisions

![simple](https://user-images.githubusercontent.com/1273879/121553133-e012c980-c9c5-11eb-83e4-c03bc990c8e8.gif)
