### PR TITLE
fix(home): switch topics to slates

### DIFF
--- a/src/common/api/graphql-queries/get-slate.js
+++ b/src/common/api/graphql-queries/get-slate.js
@@ -1,0 +1,54 @@
+import { gql } from 'graphql-request'
+const getSlate = gql`
+  query GetSlate($id: String!, $recommendationCount: Int) {
+    getSlate(slateId: $id, recommendationCount: $recommendationCount) {
+      displayName
+      description
+      displayName
+      description
+      recommendations {
+        item {
+          isArticle
+          title
+          itemId
+          normalUrl
+          resolvedId
+          resolvedUrl
+          domain
+          domainMetadata {
+            name
+          }
+          excerpt
+          hasImage
+          hasVideo
+          images {
+            caption
+            credit
+            height
+            imageId
+            src
+            width
+          }
+          topImageUrl
+          wordCount
+          timeToRead
+          givenUrl
+          syndicatedArticle {
+            slug
+            publisher {
+              name
+              url
+            }
+          }
+        }
+        id
+        curatedInfo {
+          title
+          excerpt
+          imageSrc
+        }
+      }
+    }
+  }
+`
+export default getSlate

--- a/src/common/api/topics.js
+++ b/src/common/api/topics.js
@@ -1,8 +1,22 @@
 import { request, requestGQL } from 'common/utilities/request/request'
-import { TOPIC_IDS } from 'common/constants'
+import { TOPIC_IDS, HOME_TOPIC_SLATES } from 'common/constants'
 import getSlateLineup from 'common/api/graphql-queries/get-slate-lineup'
+import getSlate from 'common/api/graphql-queries/get-slate'
 import { getRecIds } from 'common/utilities'
 import { recommendationsFromSlate } from 'common/utilities'
+
+export async function getHomeTopicFeed(topic, recommendationCount = 6) {
+  return requestGQL({
+    query: getSlate,
+    variables: { id: HOME_TOPIC_SLATES[topic], recommendationCount }
+  })
+    .then((response) => {
+      const slate = response?.data?.getSlate
+      const curated = recommendationsFromSlate(slate, topic)
+      return { curated }
+    })
+    .catch((error) => console.error(error))
+}
 
 export async function getNewTopicFeed(topic, recommendationCount = 30) {
   return requestGQL({

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -147,6 +147,25 @@ export const LOCALE_COMMON = [
   'whats-new',
 ]
 
+    
+export const HOME_TOPIC_SLATES = {
+  'business': 'af2cc2c0-1286-47a3-b8ce-187b905f94af',
+  'career': '00f0c593-3c99-4d5a-9297-c66f8b00be01',
+  'education': '856eb5f8-da7f-43ae-ac5e-25da402af0ae',
+  'entertainment': 'cceefa28-906e-47c5-b704-8c5b824ecd1b',
+  'food': '651d27ab-a898-4173-9700-dd1726fbaaa4',
+  'gaming': '951ae6c3-4438-458b-9936-7f3b8ff0f178',
+  'health': '47023d21-0aa6-4f98-9077-eac21fad44f1',
+  'parenting': '1a8de2be-db03-4a2f-901a-7c4c1cbd156a',
+  'personal-finance': 'f4b58337-4ab6-4563-9503-c384e773946f',
+  'politics': 'f8c945b0-52fa-4203-bb31-6747245fe021',
+  'science': 'b548b456-70c4-474d-a723-80d040d00fec',
+  'self-improvement': '5674f085-07b6-43c3-bcde-2774db3f6384',
+  'sports': 'e6c00454-4a00-47c1-8f22-906122c261ed',
+  'technology': 'ed9604ce-b752-48bd-b8c5-3a8cf6b54ced',
+  'travel': '4345efa7-2c89-4884-b836-3260757a3a97'
+}
+
 export const TOPIC_IDS = {
   business: {
     id: 'c18b41d8-8100-4037-aa64-416994e1d4cf',

--- a/src/containers/home/home.state.js
+++ b/src/containers/home/home.state.js
@@ -1,6 +1,6 @@
 import { put, takeEvery, select } from 'redux-saga/effects'
 import { getMyList } from 'common/api/my-list'
-import { getTopicFeed } from 'common/api/topics'
+import { getHomeTopicFeed } from 'common/api/topics'
 import { getCollections as apiGetCollections } from 'common/api/collections'
 import { saveItem } from 'common/api/saveItem'
 import { removeItem } from 'common/api/removeItem'
@@ -35,8 +35,6 @@ import { HOME_RECENT_SAVES_SUCCESS } from 'actions'
 import { HOME_RECENT_SAVES_FAILURE } from 'actions'
 
 import { HOME_SET_IMPRESSION } from 'actions'
-
-import { ITEMS_DELETE_SEND } from 'actions'
 
 import { SNOWPLOW_TRACK_PAGE_VIEW } from 'actions'
 
@@ -252,9 +250,7 @@ function* setTopicPreferences({ topic }) {
 
 function* unsetTopicPreferences({ topic }) {
   const topicSections = yield select(getTopicSections)
-  const pinnedTopics = topicSections.filter(
-    (section) => section.topic_slug !== topic.topic_slug
-  )
+  const pinnedTopics = topicSections.filter((section) => section.topic_slug !== topic.topic_slug)
 
   yield put({ type: PINNED_TOPICS_SET, pinnedTopics })
 }
@@ -294,7 +290,7 @@ export async function fetchMyListData(params) {
  */
 export async function fetchTopicData({ topic }) {
   try {
-    const response = await getTopicFeed(topic, 12, 0, false)
+    const response = await getHomeTopicFeed(topic)
 
     if (!response.curated) return { error: 'No Items Returned' }
 

--- a/src/containers/home/listTopics.js
+++ b/src/containers/home/listTopics.js
@@ -1,6 +1,5 @@
 import { HomeTopicHeader } from 'components/headers/home-header'
-import { useSelector } from 'react-redux'
-import { useDispatch } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import { css } from 'linaria'
 import { CardTopic } from 'connectors/item-card/home/card-topic'
 import { cardGrid } from 'components/items-layout/base'
@@ -148,6 +147,8 @@ export const HomeTopicsList = ({ count }) => {
   const pinnedTopics = useSelector((state) => state.settings.pinnedTopics)
 
   return pinnedTopics?.length
-    ? pinnedTopics.map((topic) => <HomeTopicsRow key={topic.display_name} count={count} {...topic} />)
+    ? pinnedTopics.map((topic) => (
+        <HomeTopicsRow key={topic.display_name} count={count} {...topic} />
+      ))
     : null
 }


### PR DESCRIPTION
## Goal

We were using the old v3 feed for topics on home. This switches to using slates.

## To Do:

- [x] add getSlate query
- [x] use getSlate query
- [x] enjoy getSlate query
- [x] mistrust getSlate query (hardcoding for the 😢 )
- [x] accept getSlate query

![Screen Shot 2021-06-14 at 10 18 17 AM](https://user-images.githubusercontent.com/16119672/121933042-672fac80-ccfa-11eb-888d-e8cf8492c766.png)

