### PR TITLE
fix(qa): adding new data-cy attributes to headers, report form, and toasts [FRONT-1212]

### DIFF
--- a/src/components/content-author/author-byline.js
+++ b/src/components/content-author/author-byline.js
@@ -61,7 +61,7 @@ function Authors({ authors }) {
   return (
     <ul>
       {authors.map((author) => (
-        <li key={`author-byline-${author}`} itemProp="author">
+        <li key={`author-byline-${author}`} itemProp="author" data-cy="author">
           {author}
         </li>
       ))}

--- a/src/components/content-headline/parsed-headline.js
+++ b/src/components/content-headline/parsed-headline.js
@@ -34,7 +34,7 @@ const Description = css`
 export function ParsedHeadline({ title, description, useMarkdown }) {
   return (
     <>
-      <h1 className={Headline}>{title}</h1>
+      <h1 className={Headline} data-cy="parsed-headline">{title}</h1>
       <h2 className={Description}>
         {useMarkdown ? (
           <ReactMarkdown skipHtml={true} unwrapDisallowed={true} allowedElements={['strong', 'em']}>

--- a/src/components/headers/discover-header.js
+++ b/src/components/headers/discover-header.js
@@ -104,7 +104,7 @@ const cardListHeadingStyle = css`
 export const CardPageHeader = ({ title, subHeading }) => {
   return title ? (
     <header className={cardPageHeaderStyle}>
-      <h1 className="pageTitle">{title}</h1>
+      <h1 className="pageTitle" data-cy="page-title">{title}</h1>
       {subHeading ? <h2 className={cx('h3', subHeadingStyle)}>{subHeading}</h2> : null}
     </header>
   ) : null

--- a/src/components/headers/messages-header.js
+++ b/src/components/headers/messages-header.js
@@ -41,7 +41,7 @@ const messagesHeaderStyle = css`
 export const MessagesHeader = ({ title }) => {
   return (
     <header className={messagesHeaderStyle}>
-      <h1 className="pageTitle">{capitalizeFirstLetter(title)}</h1>
+      <h1 className="pageTitle" data-cy="page-title">{capitalizeFirstLetter(title)}</h1>
     </header>
   )
 }

--- a/src/components/headers/my-list-header.js
+++ b/src/components/headers/my-list-header.js
@@ -69,7 +69,7 @@ export const myListHeaderStyle = css`
 export const MyListHeader = ({ subset, filter, title, sortOrder, toggleSortOrder }) => {
   return subset ? (
     <header className={myListHeaderStyle}>
-      <h1 className="pageTitle">{capitalizeFirstLetter(title)}</h1>
+      <h1 className="pageTitle" data-cy="page-title">{capitalizeFirstLetter(title)}</h1>
       <FilterMenu subset={subset} filter={filter} />
       { subset !== 'tag-page' ? (
         <ListSort toggleSortOrder={toggleSortOrder} sortOrder={sortOrder} />

--- a/src/components/headers/search-page-header.js
+++ b/src/components/headers/search-page-header.js
@@ -23,8 +23,8 @@ export const SearchPageHeader = ({ filter, total, query, sortOrder, toggleSortOr
   const isLoading = total === false
   return query ? (
     <header className={cx(myListHeaderStyle, searchStyles)}>
-      <h1 className="pageTitle">
-        <em>"{query}"</em> —{' '}
+      <h1 className="pageTitle" data-cy="page-title">
+        <em data-cy="search-query">"{query}"</em> —{' '}
         {isLoading ? (
           <span>
             Searching <Loader />{' '}

--- a/src/components/headers/tag-page-header.js
+++ b/src/components/headers/tag-page-header.js
@@ -70,7 +70,7 @@ export const TaggedHeader = ({
   return (
     <div className={tagPageHeaderStyle}>
       <header className={myListHeaderStyle}>
-        <h1 className="pageTitle">{capitalizeFirstLetter(title)}</h1>
+        <h1 className="pageTitle" data-cy="page-title">{capitalizeFirstLetter(title)}</h1>
         <FilterMenu subset={subset} filter={filter} tag={tag} />
         <ListSort toggleSortOrder={toggleSortOrder} sortOrder={sortOrder} />
       </header>

--- a/src/components/headers/whats-new-header.js
+++ b/src/components/headers/whats-new-header.js
@@ -41,7 +41,7 @@ const whatsNewHeaderStyle = css`
 export const WhatsNewHeader = ({ title }) => {
   return (
     <header className={whatsNewHeaderStyle}>
-      <h1 className="pageTitle">{capitalizeFirstLetter(title)}</h1>
+      <h1 className="pageTitle" data-cy="page-title">{capitalizeFirstLetter(title)}</h1>
     </header>
   )
 }

--- a/src/components/item-card/card.js
+++ b/src/components/item-card/card.js
@@ -160,6 +160,7 @@ export const Card = (props) => {
                 <a
                   ref={linkRef}
                   onClick={onOpen}
+                  data-cy="title-link"
                   target={openExternal ? '_blank' : undefined}
                   tabIndex={0}
                   onFocus={handleFocus}>
@@ -186,11 +187,14 @@ export const Card = (props) => {
                 href={open_url}
                 target="_blank"
                 onClick={onOpenOriginalUrl}
+                data-cy="publisher-link"
                 tabIndex={0}>
                 {publisher}
               </a>
             ) : null}
-            {read_time ? <span className="readtime"> · {read_time} min</span> : null}
+            {read_time ? (
+              <span className="readtime" data-cy="read-time"> · {read_time} min</span>
+            ) : null}
             {syndicated ? (
               <span className="syndicated">
                 <SyndicatedIcon />

--- a/src/components/items-media/card-media.js
+++ b/src/components/items-media/card-media.js
@@ -130,7 +130,7 @@ export const CardMedia = function ({
     <div className={`${cardMediaStyles} media`}>
       {openUrl ? (
         <Link href={openUrl ? openUrl : false}>
-          <a tabIndex="-1" onClick={onOpen} target={openExternal ? '_blank' : undefined}>
+          <a tabIndex="-1" data-cy="image-link" onClick={onOpen} target={openExternal ? '_blank' : undefined}>
             <MediaImage />
           </a>
         </Link>

--- a/src/components/list-filter-menu/list-filter-menu.js
+++ b/src/components/list-filter-menu/list-filter-menu.js
@@ -103,7 +103,7 @@ export function FilterMenu({ subset, filter, tag, query }) {
 
   return hasFilter ? (
     <div className={cx(filterStyle, 'filter-wrapper')}>
-      <button ref={popTrigger} className={cx(buttonReset, 'filter-trigger')}>
+      <button ref={popTrigger} data-cy="filter-trigger" className={cx(buttonReset, 'filter-trigger')}>
         {activeTitle}
         <ChevronDownIcon style={{ marginTop: 0, paddingLeft: '3px' }} />
       </button>

--- a/src/components/modal/modal-header.js
+++ b/src/components/modal/modal-header.js
@@ -23,6 +23,7 @@ const modalHeaderStyles = css`
 export const ModalHeader = ({ title, hasBorder, isSticky, className }) => {
   return (
     <h6
+      data-cy="modal-header"
       className={classnames(
         modalHeaderStyles,
         {

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -269,6 +269,7 @@ const CloseButton = ({ handleClose }) => {
 
   return (
     <button
+      data-cy="close-modal"
       className={closeButtonStyles}
       aria-label={t('common:close-label', 'Close')}
       onClick={handleClose}>

--- a/src/components/report-form/report-form.js
+++ b/src/components/report-form/report-form.js
@@ -49,6 +49,7 @@ export function ReportForm({
             name="reason"
             value={id}
             id={id}
+            data-cy={id}
             onChange={handleRadioChange}
             checked={currentReason === id}
           />

--- a/src/connectors/confirm-report/confirm-report.js
+++ b/src/connectors/confirm-report/confirm-report.js
@@ -1,4 +1,5 @@
-import { Modal, ModalBody, ModalFooter, Button, TextArea } from '@pocket/web-ui'
+import { Button } from '@pocket/web-ui'
+import { Modal, ModalBody, ModalFooter } from 'components/modal/modal'
 import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { itemReportConfirm } from 'connectors/items-by-id/discover/items.report'
@@ -98,7 +99,7 @@ export const ReportFeedbackModal = () => {
       </ModalBody>
       {success ? null : (
         <ModalFooter>
-          <Button type="submit" onClick={confirmReport} autoFocus={true}>
+          <Button type="submit" data-cy="submit-report-feedback" onClick={confirmReport} autoFocus={true}>
             <Trans i18nKey="confirm:report-feedback">Report Feedback</Trans>
           </Button>
         </ModalFooter>

--- a/src/connectors/toasts/toast.js
+++ b/src/connectors/toasts/toast.js
@@ -140,7 +140,7 @@ export function Toast({ stamp, type, itemCount = 1 }) {
   return (
     <Fade show={show} remove={remove}>
       <div className={toastWrapper}>
-        <div className={cx(toastBlock, `${type}`)}>
+        <div className={cx(toastBlock, `${type}`)} data-cy={messages[type]}>
           <div>
             <Trans i18nKey={messages[type]} count={itemCount} />
           </div>


### PR DESCRIPTION
## Goal

Adding new `data-cy` attributes to elements per Mini's request

## To Do:

- [x] There's a few, check out the ticket for info: https://getpocket.atlassian.net/browse/FRONT-1212
- [x] Removing last instance of Modal from `web-ui`!!

## Implementation Decisions

We can finally track the Modal component from `web-ui`, we're no longer using it ANYWHERE