### PR TITLE
fix(home): don’t allow read-now

### DIFF
--- a/src/connectors/item-card/home/card-rec-actions.js
+++ b/src/connectors/item-card/home/card-rec-actions.js
@@ -28,7 +28,7 @@ export function ActionsRec({ id, position }) {
   return item ? (
     <div className={`${itemActionStyle} actions`}>
       <SaveToPocket
-        allowRead={true}
+        allowRead={false}
         url={url}
         onOpen={onOpen}
         openExternal={openExternal}

--- a/src/connectors/item-card/home/card-topic-actions.js
+++ b/src/connectors/item-card/home/card-topic-actions.js
@@ -28,7 +28,7 @@ export function ActionsTopic({ id, position }) {
   return item ? (
     <div className={`${itemActionStyle} actions`}>
       <SaveToPocket
-        allowRead={true}
+        allowRead={false}
         url={url}
         onOpen={onOpen}
         openExternal={openExternal}


### PR DESCRIPTION
## Goal

Turn off `read-now` option for home cards

## To Do:

- [x] Disallow read-now on home item card actions

## Implementation Decisions

 Read-now needs to be adjusted a bit to be more consistent across the product.  For now as a stop-gap to avoid confusion, we can just make it a straight save.
