### PR TITLE
fix(cypress): adding data-cy attributes for publisher, save popup, and unpin tags

### DIFF
--- a/src/components/content-author/author-byline.js
+++ b/src/components/content-author/author-byline.js
@@ -79,7 +79,7 @@ function Authors({ authors }) {
 function AuthorByline({ url, name, showAuthors, authorNames }) {
   return (
     <cite className={BylineWrapper}>
-      <a href={url}>{name}</a>
+      <a href={url} data-cy="author-url">{name}</a>
       {showAuthors ? <Authors authors={authorNames} /> : null}
     </cite>
   )

--- a/src/components/headers/tag-page-header.js
+++ b/src/components/headers/tag-page-header.js
@@ -76,9 +76,9 @@ export const TaggedHeader = ({
       </header>
       <div className="tag-actions">
         <button
-          aria-label={t('nav:pin-tag', 'Pin Tag')}
-          data-tooltip={t('nav:pin-tag', 'Pin Tag')}
-          data-cy="tag-pin"
+          aria-label={isPinned ? t('nav:unpin-tag', 'Unpin Tag') : t('nav:pin-tag', 'Pin Tag')}
+          data-tooltip={isPinned ? t('nav:unpin-tag', 'Unpin Tag') : t('nav:pin-tag', 'Pin Tag')}
+          data-cy={isPinned ? 'tag-unpin' : 'tag-pin'}
           className={cx(buttonReset, bottomTooltipDelayed)}
           onClick={pinTag}>
           {isPinned ? <PinFilledIcon /> : <PinIcon />}

--- a/src/components/item-actions/save-to-pocket.js
+++ b/src/components/item-actions/save-to-pocket.js
@@ -94,8 +94,8 @@ export const SavePopover = function ({ popoverRef, id }) {
     //prettier-ignore
     <div className={popoverContainer} ref={popoverRef} data-cy={`article-save-login-popup-${id}`}>
       <Trans i18nKey="item-action:no-auth-save">
-        <a className="popoverLink" href={loginUrl}>Log in</a> or{' '}
-        <a className="popoverLink" href={signupUrl}>Sign up</a> to save this article.    
+        <a className="popoverLink" href={loginUrl} data-cy="save-login">Log in</a> or{' '}
+        <a className="popoverLink" href={signupUrl} data-cy="save-signup">Sign up</a> to save this article.
       </Trans>
     </div>
   )


### PR DESCRIPTION
## Goal

Adding new `data-cy` attributes

## To Do:

- [x] Syndicated article publisher
- [x] Save popup when logged out
- [x] Unpin tags

## Implementation Decisions

I thought long and hard about this (no I didn't).

![lemons3](https://user-images.githubusercontent.com/1273879/124809026-7e864200-df14-11eb-8b8e-2aabbc40bedd.gif)
