### PR TITLE
fix(snowplow): copy items to avoid mutation

### DIFF
--- a/src/connectors/snowplow/snowplow.state.js
+++ b/src/connectors/snowplow/snowplow.state.js
@@ -55,7 +55,10 @@ import { legacyAnalyticsTrack } from 'common/api/legacy-analytics'
  --------------------------------------------------------------- */
 export const finalizeSnowplow = () => ({ type: SNOWPLOW_INITIALIZED })
 
-export const updateAnonymousTracking = (track) => ({ type: SNOWPLOW_UPDATE_ANONYMOUS_TRACKING, track })
+export const updateAnonymousTracking = (track) => ({
+  type: SNOWPLOW_UPDATE_ANONYMOUS_TRACKING,
+  track
+})
 
 export const trackPageView = () => ({ type: SNOWPLOW_TRACK_PAGE_VIEW })
 
@@ -355,7 +358,7 @@ function* fireImpression({ component, requirement, ui, position, identifier }) {
 function* fireContentEngagement({ component, ui, identifier, position, items }) {
   const engagementEvent = createEngagementEvent(component)
 
-  const contentEntities = items.length ? items : [items]
+  const contentEntities = items.length ? [...items] : [items]
   // limit content entities to BATCH_SIZE = 30
   if (contentEntities.length > BATCH_SIZE) contentEntities.length = BATCH_SIZE
 


### PR DESCRIPTION
## Goal

Batch processing was maxing out at 30 items. This was due to the analytics call mutating the state.  This makes a copy before performing any edits.

## To Do:

- [x] create copy of items instead of a reference

## Implementation Decisions

I am guessing there is some efficiency updates we could make here, but I am only trying to fix the error, not adjust the logic because @anthony-liddle has a large update to the analytics code that will most likely render this fix unnecessary.

![giphy](https://user-images.githubusercontent.com/16119672/124817704-fc4f4b00-df1e-11eb-81d8-582fe2b653d9.gif)
