### PR TITLE
fix(sentry): add some filtering client side

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -15,7 +15,39 @@ Sentry.init({
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps
-
-  release: process.env.BUILD_ID,
+  beforeSend(event, hint) {
+    const error = hint.originalException
+    // Snowplow trys to adjust userAgent which is a problem client side
+    if (error?.message?.match(/userAgent/i)) return null
+    if (error?.message?.match(/pubads_impl/i)) return null
+    return event
+  },
+  ignoreErrors: [
+    // Random plugins/extensions
+    'top.GLOBALS',
+    // See: http://blog.errorception.com/2012/03/tale-of-unfindable-js-error.html
+    'originalCreateNotification',
+    'canvas.contentDocument',
+    // Facebook borked
+    'fb_xd_fragment',
+    // ISP "optimizing" proxy - `Cache-Control: no-transform` seems to
+    // reduce this. (thanks @acdha)
+    // See http://stackoverflow.com/questions/4113268
+    'bmi_SafeAddOnload',
+    'EBCallBackMessageReceived',
+    // See http://toolbar.conduit.com/Developer/HtmlAndGadget/Methods/JSInjection.aspx
+    'conduitPage'
+  ],
+  denyUrls: [
+    // Ignore Google flakiness
+    /\/(gtm|ga|analytics)\.js/i,
+    // Facebook flakiness
+    /graph\.facebook\.com/i,
+    // Facebook blocked
+    /connect\.facebook\.net\/en_US\/all\.js/i,
+    // Chrome extensions
+    /extensions\//i,
+    /^chrome:\/\//i
+  ],
   environment: isDev ? 'Development' : 'Production'
 })


### PR DESCRIPTION
## Goal

Filter out the third party noise in our sentry

## To Do:

- [x] General filtering example from Sentry
- [x] Filter out userAgent errors from snowplow
- [x] Filter out `pubads_impl` errors from google ads

## Implementation Decisions

Just trying to get stuff we don't control out of sentry.