### PR TITLE
fix(sentry): remove userAgent block - add release

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -18,8 +18,9 @@ Sentry.init({
   beforeSend(event, hint) {
     const error = hint.originalException
     // Snowplow trys to adjust userAgent which is a problem client side
-    if (error?.message?.match(/userAgent/i)) return null
-    if (error?.message?.match(/pubads_impl/i)) return null
+    if (error && error.message) {
+      if (error.message.match(/pubads_impl/i)) return null
+    }
     return event
   },
   ignoreErrors: [
@@ -49,5 +50,6 @@ Sentry.init({
     /extensions\//i,
     /^chrome:\/\//i
   ],
+  release: process.env.BUILD_ID,
   environment: isDev ? 'Development' : 'Production'
 })

--- a/server.local.js
+++ b/server.local.js
@@ -1,7 +1,6 @@
 var https = require('https')
 var http = require('http')
 var fs = require('fs')
-const path = require('path')
 const { parse } = require('url')
 
 const next = require('next')


### PR DESCRIPTION
## Goal

Sentry Release didn't get any adoption so loosening up the restrictions and adding back in the release as buildID.  If this fails, I will add back the sentry release notification in CI

## To Do:

- [x] Add release back to config
- [x] Remove userAgent as that will probably always match
