### PR TITLE
fix(sentry): limit pubads errors stemming from crawlers

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -19,6 +19,11 @@ Sentry.init({
   // that it will also get attached to your source maps
   beforeSend(event, hint) {
     const error = hint.originalException
+    // Per this thread https://github.com/getsentry/sentry-javascript/issues/1811
+    if (window && window.location && window.location.search) {
+      if (window.location.search.indexOf('fbclid') !== -1) return null
+    }
+
     // Snowplow trys to adjust userAgent which is a problem client side
     if (error && error.message) {
       if (error.message.match(/pubads_impl/i)) return null


### PR DESCRIPTION
## Goal

We get a boatload of `pubad_imp` errors that can be traced to urls with `fbclid` in the url. Apparently these are facebook crawlers.  Since this issue is not a ux or performance issue, I am inclined to take the fix sentry is suggesting here.

## To Do:

- [x] Limit client side crawlers (facebook) from falling into our sentry errors.

## Implementation Decisions

The level of effort to get sentry working client side feels much bigger than the benefit.  Hopefully, once we are clear of this, I will be proven wrong.

![giphy-3](https://user-images.githubusercontent.com/16119672/126258968-00879a1f-871e-4c09-b927-e7843c72f5be.gif)
