### PR TITLE
fix(sentry): group mobile web view errors

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -14,9 +14,17 @@ Sentry.init({
   sampleRate: 0.5,
   beforeSend(event, hint) {
     const error = hint.originalException
-    // Per this thread https://github.com/getsentry/sentry-javascript/issues/1811
+
     if (window && window.location && window.location.search) {
+      // Per this thread https://github.com/getsentry/sentry-javascript/issues/1811
       if (window.location.search.indexOf('fbclid') !== -1) return null
+
+      // This will group the article not found errors as it seems to be another ios injection error
+      // We are not gonna ignore it until that's confirmed but it will give us a clearer sense
+      // of volume
+      if (window.location.search.indexIf('mobile_web_view') !== -1) {
+        event.fingerprint = ['mobile-web-view']
+      }
     }
 
     // Pocket IOS injection error


### PR DESCRIPTION
## Goal
This should allow us to better ignoring rules in place for this error that I am 99% sure comes from a mobile injection.

## To Do:

- [x] Fingerprint `mobile web view` errors regardless of url

## Implementation Decisions

All these errors are generated per article for mobile_web_view.  This appears to be another injection issue, but seeing as it's so nebulous I am not going to ignore it ... yet.

![Screen Shot 2021-07-20 at 12 28 48 PM](https://user-images.githubusercontent.com/16119672/126384182-5f052537-76f7-44c2-9a5f-38363eae1644.png)