### PR TITLE
fix(sentry): improve ignoring for unrelated errors

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -27,20 +27,21 @@ Sentry.init({
       }
     }
 
-    // Pocket IOS injection error
     if (error && error.message) {
+      // Pocket IOS injection error
       if (error.message.match(/pktAnnotationHighlighter/i)) return null
-    }
 
-    // Firefox Extension misbehaving
-    if (error && error.message) {
+      // Firefox Extension misbehaving
       if (error.message.match(/can't access dead object/i)) return null
+
+      // Apple mail peek error (we don't use a raw variable `article`)
+      if (error.message.match(/Can't find variable: article/i)) return null
+
+      // Snowplow trying to redefine the user agent
+      // !! NOTE: we should remove this once we upgrade snowplow for the browser
+      if (error.message.match(/can't redefine non-configurable property "userAgent"/i)) return null
     }
 
-    // Apple mail peek error (we don't use a raw variable `article`)
-    if (error && error.message) {
-      if (error.message.match(/Can't find variable: article/i)) return null
-    }
     return event
   },
   whitelistUrls: [/https:\/\/(.+)?getpocket\.com/],

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -15,20 +15,21 @@ Sentry.init({
   beforeSend(event, hint) {
     const error = hint.originalException
 
-    // Pocket IOS injection error
     if (error && error.message) {
+      // Pocket IOS injection error
       if (error.message.match(/pktAnnotationHighlighter/i)) return null
-    }
 
-    // Firefox Extension misbehaving
-    if (error && error.message) {
+      // Firefox Extension misbehaving
       if (error.message.match(/can't access dead object/i)) return null
+
+      // Apple mail peek error (we don't use a raw variable `article`)
+      if (error.message.match(/Can't find variable: article/i)) return null
+
+      // Snowplow trying to redefine the user agent
+      // !! NOTE: we should remove this once we upgrade snowplow for the browser
+      if (error.message.match(/can't redefine non-configurable property "userAgent"/i)) return null
     }
 
-    // Apple mail peek error (we don't use a raw variable `article`)
-    if (error && error.message) {
-      if (error.message.match(/Can't find variable: article/i)) return null
-    }
     return event
   }
 })


### PR DESCRIPTION
## Goal

Ignore some more errors that are not from us.

## To Do:

- [x] Ignore Apple Mail Error with article variable
- [x] Ignore dead object (sentry only ignores handled errors in `ignore errors` setting

## Implementation Decisions

The cannot find article is not from us, and the user agent is appleMail a majority of the time.  Also we don't use a raw variable `article` in our syndicated content

The dead object error is from a Firefox extension.  This just moves it to a place where it can actually get dropped.

## Before you Submit
![giphy](https://user-images.githubusercontent.com/16119672/126527650-10538bab-7dab-4657-9960-a482fdc2d084.gif)
