### PR TITLE
fix(collections): add custom events for collection stories

### DIFF
--- a/src/connectors/item-card/collection/story-actions.js
+++ b/src/connectors/item-card/collection/story-actions.js
@@ -24,11 +24,11 @@ export function ActionsCollection({ id, position }) {
   // Prep save action
   const onSave = () => {
     dispatch(saveStory(id, url))
-    dispatch(sendSnowplowEvent('collection.save', analyticsData))
+    dispatch(sendSnowplowEvent('collection.story.save', analyticsData))
   }
 
   // Open action
-  const onOpen = () => dispatch(sendSnowplowEvent('collection.open', analyticsData))
+  const onOpen = () => dispatch(sendSnowplowEvent('collection.story.open', analyticsData))
 
   return item ? (
     <div className={`${itemActionStyle} actions`}>

--- a/src/connectors/item-card/collection/story-card.js
+++ b/src/connectors/item-card/collection/story-card.js
@@ -20,10 +20,10 @@ export function ItemCard({ id, cardShape, className, showExcerpt = false, positi
   )
 
   if (!item) return null
-  const { url } = item
+  const { open_url } = item
   const onImageFail = () => dispatch(setNoImage(id))
   const analyticsData = {
-    url,
+    url: open_url,
     position,
     destination: 'external'
   }
@@ -32,10 +32,10 @@ export function ItemCard({ id, cardShape, className, showExcerpt = false, positi
    * ITEM TRACKING
    * ----------------------------------------------------------------
    */
-  const onImpression = () => dispatch(sendSnowplowEvent('collection.impression', analyticsData))
+  const onImpression = () => dispatch(sendSnowplowEvent('collection.story.impression', analyticsData))
   const onItemInView = (inView) =>
     !impressionFired && inView && analyticsInitialized ? onImpression() : null
-  const onOpen = () => dispatch(sendSnowplowEvent('collection.open', analyticsData))
+  const onOpen = () => dispatch(sendSnowplowEvent('collection.story.open', analyticsData))
 
   return (
     <Card
@@ -45,7 +45,7 @@ export function ItemCard({ id, cardShape, className, showExcerpt = false, positi
       className={className}
       cardShape={cardShape}
       showExcerpt={showExcerpt}
-      openUrl={url}
+      openUrl={open_url}
       useMarkdown={true}
       // Tracking
       onItemInView={onItemInView}

--- a/src/connectors/snowplow/actions/collections.js
+++ b/src/connectors/snowplow/actions/collections.js
@@ -25,6 +25,32 @@ export const collectionsActions = {
     },
     expects: ['url', 'position']
   },
+  'collection.story.impression': {
+    eventType: 'impression',
+    entityTypes: ['content', 'ui'],
+    eventData: {
+      component: 'ui',
+      uiType: 'card'
+    },
+    expects: ['url', 'position']
+  },
+  'collection.story.open': {
+    eventType: 'contentOpen',
+    entityTypes: ['content', 'ui'],
+    eventData: {
+      uiType: 'card'
+    },
+    expects: ['url', 'position', 'destination']
+  },
+  'collection.story.save': {
+    eventType: 'engagement',
+    entityTypes: ['content', 'ui'],
+    eventData: {
+      engagementType: 'save',
+      uiType: 'button'
+    },
+    expects: ['url', 'position']
+  },
   'collection.page.save': {
     eventType: 'engagement',
     entityTypes: ['content', 'ui'],


### PR DESCRIPTION
## Goal

Adding analytics events for Collections story pages

## To Do:

- [x] Add analytics for collections story page

## Implementation Decisions

There was a bug with analytics events with collections stories, and I noticed that this page was using the same events as the `/collections` page. 
