### PR TITLE
fix(syndicated): pass article title to layout component [FRONT-1310]

### DIFF
--- a/src/containers/syndicated-article/syndicated-article.js
+++ b/src/containers/syndicated-article/syndicated-article.js
@@ -107,7 +107,7 @@ export function SyndicatedArticle({ queryParams = validParams }) {
 
   return (
     <>
-      <ArticleLayout metaData={articleMetaData} canonical={canonical} className={printLayout}>
+      <ArticleLayout title={title} metaData={articleMetaData} canonical={canonical} className={printLayout}>
         <main className={contentLayout}>
           <section>
             <AdAboveTheFold


### PR DESCRIPTION
## Goal

Add the article title back to the browser tab `title`

## To Do:

- [x] Pass article title to layout component

## Implementation Decisions

Lemonssssssss

![easy](https://user-images.githubusercontent.com/1273879/127387916-1348efbf-f424-412f-8396-4ab50832b618.gif)
