### PR TITLE
fix(home): remove padding on topic selector for mobile

### DIFF
--- a/src/containers/home/topicSelector.js
+++ b/src/containers/home/topicSelector.js
@@ -8,6 +8,7 @@ import { setTopicSection } from 'containers/home/home.state'
 import { unsetTopicSection } from 'containers/home/home.state'
 import { sendSnowplowEvent } from 'connectors/snowplow/snowplow.state'
 import { topicHeadings } from './listTopics'
+import { breakpointLargeHandset } from '@pocket/web-ui'
 
 const selectionStyles = css`
   padding: 2rem 0;
@@ -15,6 +16,10 @@ const selectionStyles = css`
 
 export const pillboxStyle = css`
   padding: 0 3rem 1.5rem;
+
+  ${breakpointLargeHandset} {
+    padding: 0 0 1.5rem;
+  }
 
   .pillContainer {
     display: flex;


### PR DESCRIPTION
## Goal

Removing padding on topic selector for mobile

## To Do:

- [x] padding left/right is zero on large handset and below

## Implementation Decisions

![giphy](https://user-images.githubusercontent.com/1273879/127553790-e140c9ca-046f-46dc-96d0-61228e9e046e.gif)
