### PR TITLE
fix(home): display two latest collections

### DIFF
--- a/src/containers/home/home.state.js
+++ b/src/containers/home/home.state.js
@@ -301,7 +301,7 @@ export async function fetchCollectionData({ count }) {
       ...collection,
       url: `/collections/${collection.slug}`
     }))
-    const data = collectionsWithUrl.sort(() => 0.5 - Math.random()).slice(0, count)
+    const data = collectionsWithUrl.slice(0, count)
     return { data }
   } catch (error) {
     //TODO: adjust this once error reporting strategy is defined.


### PR DESCRIPTION
## Goal

Update collections on Home to display the two latest instead of a random two

## To Do:

- [x] update collections filtering on Home

## Implementation Decisions

This decision was based on this slack thread:
https://pocket.slack.com/archives/C01RJTJBLQ6/p1627583759010100

![home](https://user-images.githubusercontent.com/1273879/127565007-1065c08a-e8d0-4e80-8af0-0306bd21eddd.gif)
