### PR TITLE
fix(collections): add signup callout to collections for logged out users

### DIFF
--- a/src/components/call-out/call-out-build-home.js
+++ b/src/components/call-out/call-out-build-home.js
@@ -130,7 +130,7 @@ const wrapper = css`
   }
 `
 
-export function CallOutBuildHome() {
+export function CallOutBuildHome({ source = 'explore' }) {
   const { t } = useTranslation()
   return (
     <div className={wrapper} data-cy="signup-module">
@@ -149,7 +149,7 @@ export function CallOutBuildHome() {
           id="explore-signup-hero" // needed for snowplow identifier
           variant="brand"
           target="_blank"
-          href={`${SIGNUP_URL}?utm_source=explore&utm_medium=web`}>
+          href={`${SIGNUP_URL}?utm_source=${source}&utm_medium=web`}>
           Sign&nbsp;Up
         </Button>
       </aside>

--- a/src/containers/collections/collections.js
+++ b/src/containers/collections/collections.js
@@ -2,6 +2,7 @@ import Layout from 'layouts/main'
 
 import { useSelector } from 'react-redux'
 
+import { CallOutBuildHome } from 'components/call-out/call-out-build-home'
 import { CardPageHeader } from 'components/headers/discover-header'
 import { ItemCard } from 'connectors/item-card/collection/collection-card'
 import { Lockup } from 'components/items-layout/list-lockup'
@@ -12,8 +13,11 @@ import { useTranslation } from 'next-i18next'
 export default function Collections() {
   const { t } = useTranslation()
 
+  const isAuthenticated = useSelector((state) => state.user.auth)
+  const userStatus = useSelector((state) => state.user.user_status)
   const items = useSelector((state) => state.collectionsBySlug)
   const itemIds = Object.keys(items)
+  const shouldRender = userStatus !== 'pending'
 
   const metaData = {
     description: t('collections:page-description', 'Curated guides to the best of the web'),
@@ -22,6 +26,8 @@ export default function Collections() {
 
   return (
     <Layout title={metaData.title} metaData={metaData}>
+      {!isAuthenticated && shouldRender ? <CallOutBuildHome source="collections" /> : null}
+
       <CardPageHeader title={metaData.title} subHeading={metaData.description} />
 
       <Lockup items={itemIds} offset={0} heroPosition="center" ItemCard={ItemCard} />


### PR DESCRIPTION
## Goal

Request from the curation team to add the Signup module from Discover onto the Collections page

## To Do:

- [x] Add Module to collections page
- [x] Update module to allow for custom `utm_source` param on link

## Implementation Decisions

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/1273879/127908018-9c776c8e-a9d2-41d0-98b9-6078f89202d8.png">

![giphy](https://user-images.githubusercontent.com/1273879/127908041-b53513de-1728-4944-87a1-9720abfcd009.gif)
