### PR TITLE
fix(home): update page headings and topic selector placement [FRONT-1313]

### DIFF
--- a/src/containers/home/home.js
+++ b/src/containers/home/home.js
@@ -53,9 +53,9 @@ export default function Collection(props) {
         <main className="main">
           <HomeGreeting />
 
-          <HomeTopicSelector />
-
           <HomeTopicsList />
+
+          <HomeTopicSelector />
 
           <HomeCollectionList />
         </main>

--- a/src/containers/home/homeGreeting.js
+++ b/src/containers/home/homeGreeting.js
@@ -1,27 +1,23 @@
-import { css } from 'linaria'
 import { useSelector } from 'react-redux'
 import { getTimeOfDay } from 'common/utilities'
-
-const homeCollections = css`
-  font-family: 'Graphik Web';
-  font-style: normal;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.2;
-  margin-bottom: 0;
-`
+import { CardPageHeader } from 'components/headers/discover-header'
 
 export const HomeGreeting = () => {
   const firstName = useSelector((state) => state.user.first_name)
-
+  const pinnedTopics = useSelector((state) => state.settings.pinnedTopics)
   const timeOfDay = getTimeOfDay()
+
   const greeting = firstName
     ? `Good ${timeOfDay}, ${firstName}!`
     : `Good ${timeOfDay}!`
+  const description = (pinnedTopics?.length === 0)
+    ? `Select topics to see popular articles and our editors’ top picks.`
+    : null
 
   return (
-    <div className={homeCollections}>
-      {greeting}
-    </div>
+    <CardPageHeader
+      title={greeting}
+      subHeading={description}
+    />
   )
 }

--- a/src/containers/home/topicSelector.js
+++ b/src/containers/home/topicSelector.js
@@ -23,14 +23,8 @@ export const HomeTopicSelector = () => {
 
   const pinnedTopics = useSelector((state) => state.settings.pinnedTopics)
 
-  const journeyTitles = ['Start your Pocket journey', 'Discover more topics']
-  const journeySubTitles = [
-    'Select a topic to find fascinating stories from all across the web',
-    'Save today’s essential reads and find them later in My List'
-  ]
-
-  const journeyTitle = journeyTitles[Math.min(pinnedTopics?.length, Math.max(0, 1))]
-  const journeySubTitle = journeySubTitles[Math.min(pinnedTopics?.length, Math.max(0, 1))]
+  const title = `Discover more topics`
+  const description = `Select topics to see popular articles and our editors’ top picks.`
 
   const toggleCallback = (label) => {
     dispatch(sendSnowplowEvent('home.topic.toggle', { label }))
@@ -38,7 +32,7 @@ export const HomeTopicSelector = () => {
 
   return (
     <div className={selectionStyles}>
-      <HomeJourneyHeader sectionTitle={journeyTitle} sectionDescription={journeySubTitle} />
+      { (pinnedTopics?.length > 0) ? <HomeJourneyHeader sectionTitle={title} sectionDescription={description} /> : null }
       <div className={pillboxStyle}>
         <TopicSelector toggleCallback={toggleCallback}/>
       </div>


### PR DESCRIPTION
## Goal

Update page headings and placement of Topic selector

## To Do:

- [x] Update page heading
- [x] Update placement of topic selector

## Implementation Decisions

When there are no topics selected, the selector appears beneath the heading and subheading

When topics are selected, the selector appears beneath the topics rows. The heading drops the subheading. A smaller heading and subheading appears above the topic selector.


![image](https://user-images.githubusercontent.com/1273879/127928851-2e02f486-1eb6-407c-adf3-dc4d5d27d48d.png)

![image](https://user-images.githubusercontent.com/1273879/127928862-d942761b-4fd1-487d-90ce-c80e6e40eb41.png)

