### PR TITLE
fix(onboarding): add snowplow event for skipping onboarding modal

### DIFF
--- a/src/connectors/onboarding/onboarding-modal.js
+++ b/src/connectors/onboarding/onboarding-modal.js
@@ -99,15 +99,14 @@ export const OnboardingModal = () => {
     if (showModal) dispatch(sendSnowplowEvent('onboarding.welcome.impression'))
   }, [showModal])
 
-  const handleClose = () => {
-    dispatch(sendSnowplowEvent('onboarding.welcome.close'))
+  const closeModal = (identifier) => {
+    dispatch(sendSnowplowEvent(identifier))
     dispatch(onboardingCloseTopicSelectionModal())
   }
 
-  const handleContinue = () => {
-    dispatch(sendSnowplowEvent('onboarding.welcome.continue'))
-    dispatch(onboardingCloseTopicSelectionModal())
-  }
+  const handleClose = () => closeModal('onboarding.welcome.close')
+  const handleContinue = () => closeModal('onboarding.welcome.continue')
+  const handleSkip = () => closeModal('onboarding.welcome.skip')
 
   const toggleCallback = (label) => {
     dispatch(sendSnowplowEvent('onboarding.topic.toggle', { label }))
@@ -145,7 +144,7 @@ export const OnboardingModal = () => {
           type="submit"
           variant={noTopicsSelected ? 'secondary' : 'primary'}
           data-cy="onboarding-cta"
-          onClick={handleContinue}>
+          onClick={noTopicsSelected ? handleSkip : handleContinue}>
           { buttonLabel }
         </Button>
       </ModalFooter>

--- a/src/connectors/snowplow/actions/onboarding.js
+++ b/src/connectors/snowplow/actions/onboarding.js
@@ -13,6 +13,13 @@ export const onboardingActions = {
       uiType: 'button'
     }
   },
+  'onboarding.welcome.skip': {
+    eventType: 'engagement',
+    entityTypes: ['ui'],
+    eventData: {
+      uiType: 'button'
+    }
+  },
   'onboarding.welcome.impression': {
     eventType: 'impression',
     entityTypes: ['ui'],


### PR DESCRIPTION
## Goal

Adding snowplow event for skipping onboarding modal

## To Do:

- [x] Add snowplow action for skip
- [x] Hook up new snowplow event

## Implementation Decisions

Simplified the code that calls the event in the modal.