### PR TITLE
fix(onboarding): fix onboarding modal getting cut off in mobile chrome & safari [FRONT-1325]

### DIFF
--- a/src/connectors/onboarding/onboarding-modal.js
+++ b/src/connectors/onboarding/onboarding-modal.js
@@ -86,7 +86,7 @@ const modalBodyStyles = css`
 `
 
 // overrides the mobile styling due to an issue in chrome/safari where the
-// modal is too tall and gets cut off when the address bar is shown
+// modal is too tall and gets cut off on smaller devices
 const modalContentClass = css`
   ${breakpointLargeHandset} {
     max-height: 100%;


### PR DESCRIPTION
## Goal

[FRONT-1325](https://getpocket.atlassian.net/browse/FRONT-1325)

Fix the onboarding modal getting cut off in mobile chrome and safari on small devices


**BEFORE:**
Modal header was getting cut off, couldn't read "Welcome to Pocket", the `X` close button was off screen and page wouldn't scroll to get to the top of the modal.

<img width="429" alt="Screen Shot 2021-08-11 at 12 42 19 PM" src="https://user-images.githubusercontent.com/2893463/129077915-28482884-49f6-4212-9cf0-348c1954c371.png">


**AFTER:**
Modal header is no longer cut off and the page scrolls so the user can access all content.

![mobile-modal](https://user-images.githubusercontent.com/2893463/129078080-f5dddd9b-42e1-4d50-8731-a803947433b0.gif)
