### PR TITLE
fix(reader): hide sidebar unless open [FRONT-1270]

### DIFF
--- a/src/containers/read/read.js
+++ b/src/containers/read/read.js
@@ -59,9 +59,11 @@ const articleWrapper = css`
   .sidebar-anchor {
     position: relative;
     width: 0;
+    opacity: 0;
     transition: width 150ms ease-in-out;
     &.active {
       width: 350px;
+      opacity: 1;
     }
   }
 


### PR DESCRIPTION
## Goal

Hide highlights sidebar unless actively open

## To Do:

- [x] Hide highlights sidebar unless actively open

## Implementation Decisions

![giphy](https://user-images.githubusercontent.com/1273879/130124062-fd72cc8d-6a7d-4cc1-a1ad-2fa1eb99534c.gif)
