### PR TITLE
fix(collections): display collections card excerpt on mobile screen sizes [FRONT-1319]

### DIFF
--- a/src/containers/collections/collection-page.js
+++ b/src/containers/collections/collection-page.js
@@ -38,6 +38,12 @@ const itemStyles = css`
     &.wide .excerpt {
       display: block;
     }
+
+    &.wide .media,
+    &.wide .content,
+    &.wide footer.footer .actions {
+      grid-column: span 12;
+    }
   }
 `
 


### PR DESCRIPTION
## Goal

To display Collection Card excerpts on mobile screen sizes per Curation Team's request

## To Do:

- [x] Add styles to pass down to the card component

## Implementation Decisions

Passing the styles down from the Collection Container

### OLD
<img width="373" alt="image" src="https://user-images.githubusercontent.com/1273879/130692952-bd316c61-7ce8-4961-b130-00161aa85f07.png">


### NEW
<img width="374" alt="image" src="https://user-images.githubusercontent.com/1273879/130692902-c10c0eea-f9f9-4d48-badd-0a1a8ca900e2.png">


![giphy](https://user-images.githubusercontent.com/1273879/130692182-7db1461c-2b26-4649-81a6-35d3dc21af75.gif)
