### PR TITLE
fix(partner): styling fixes for dark and sepia modes

### DIFF
--- a/src/components/content-partner/partner.js
+++ b/src/components/content-partner/partner.js
@@ -1,9 +1,10 @@
 import { css } from 'linaria'
 import { useTranslation } from 'next-i18next'
+import { darkMode, sepiaMode } from '@pocket/web-ui'
 
 const partnerStyles = css`
   font-family: 'Graphik Web';
-  color: var(--color-textTertiary);
+  color: var(--color-textSecondary);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -11,11 +12,20 @@ const partnerStyles = css`
   img {
     margin-left: 0.5rem;
     max-width: 8rem;
+
+    ${darkMode} {
+      mix-blend-mode: exclusion;
+      filter: invert(1);
+    }
+
+    ${sepiaMode} {
+      mix-blend-mode: multiply;
+    }
   }
 `
 
 const overlineStyles = css`
-  color: var(--color-textTertiary);
+  color: var(--color-textSecondary);
   font-weight: 300;
   text-transform: uppercase;
   letter-spacing: 0.014em;


### PR DESCRIPTION
## Goal

Per feedback from the curation team:
* invert the publisher image on darkMode, multiply on sepiaMode
* update text color to match the other grey text elements on the page

<img width="705" alt="Screen Shot 2021-08-25 at 10 28 18 AM" src="https://user-images.githubusercontent.com/2893463/130820822-9b59df6c-93d2-4186-bb1e-cd511663514c.png">

<img width="703" alt="Screen Shot 2021-08-25 at 10 28 24 AM" src="https://user-images.githubusercontent.com/2893463/130820828-1606cedd-38ce-47e6-bdc2-660355d0ebea.png">
