### PR TITLE
fix(global-nav): update pocket logo link depending on logged in status [FRONT-1329]

### DIFF
--- a/src/connectors/global-nav/global-nav.js
+++ b/src/connectors/global-nav/global-nav.js
@@ -67,6 +67,7 @@ const GlobalNav = ({ selectedLink: selected, subset, tag }) => {
   const isPremium = useSelector((state) => parseInt(state?.user?.premium_status, 10) === 1 || false)
   const isLoggedIn = useSelector((state) => !!state.user.auth)
   const retrievedAvatar = useSelector((state) => state?.user?.profile?.avatar_url)
+  const pocketLogoOutboundUrl = isLoggedIn ? '/my-list' : '//getpocket.com'
 
   const myListFlyawayReady = useSelector((state) => state.onboarding.homeFlyawayMyList)
   const saveFlyawayStatus = useSelector((state) => state.onboarding.homeFlyawaySave)
@@ -229,7 +230,7 @@ const GlobalNav = ({ selectedLink: selected, subset, tag }) => {
 
   return (
     <GlobalNavComponent
-      pocketLogoOutboundUrl={'/'}
+      pocketLogoOutboundUrl={pocketLogoOutboundUrl}
       appRootSelector="#__next"
       links={links}
       subLinks={subLinks}


### PR DESCRIPTION
## Goal

Clicking the Pocket logo when on a foreign language page would lead to a broken page

## To Do:

- [x] If logged in, direct to My List
- [x] If logged out, direct to Pocket landing page

## Implementation Decisions

Might be better to direct to `waypoint` in the future if we want Home to be the main landing page