### PR TITLE
fix(reader): remove opacity on sidebar [FRONT-1352]

### DIFF
--- a/src/containers/read/read.js
+++ b/src/containers/read/read.js
@@ -305,16 +305,18 @@ export default function Reader() {
 
       <main className={articleWrapper}>
         <div className={classNames('sidebar-anchor', { active: sideBarOpen })}>
-          <Sidebar
-            isPremium={isPremium}
-            sideBarOpen={sideBarOpen}
-            toggleSidebar={toggleSidebar}
-            highlightList={highlightList}
-            annotationCount={annotations.length}
-            shareItem={itemShare}
-            deleteAnnotation={removeAnnotation}
-            handleImpression={handleImpression}
-          />
+          {articleContent ? (
+            <Sidebar
+              isPremium={isPremium}
+              sideBarOpen={sideBarOpen}
+              toggleSidebar={toggleSidebar}
+              highlightList={highlightList}
+              annotationCount={annotations.length}
+              shareItem={itemShare}
+              deleteAnnotation={removeAnnotation}
+              handleImpression={handleImpression}
+            />
+          ) : null}
         </div>
         <article
           className={classNames(


### PR DESCRIPTION
## Goal

Undoing a change from last week that hid the highlights sidebar before it had been opened. The change had the unintended consequence of making the tic marks and the sidebar toggle button invisible.

## To Do:

- [x] Undo change from last week
- [x] BONUS: Only display the flyway in the Reader view once the article content exists

## Implementation Decisions

I noticed the flyaway would appear before the article content, and then jump to the bottom of the page. By waiting until the article content exists it appears exactly where it should.