### PR TITLE
fix(snowplow): update snowplow post path for dev environments

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -38,10 +38,7 @@ export const GREENHOUSE_JOBS_URL = 'https://boards-api.greenhouse.io/v1/boards/p
 // SNOWPLOW
 export const API_USER_ID = 89624 // Pocket backend identifier for an API user used in Snowplow analytic events
 export const SNOWPLOW_SCRIPT = 'https://assets.getpocket.com/web-utilities/public/static/te-3.1.2.js'
-export const SNOWPLOW_POST_PATH = process.env.SHOW_DEV === 'included'
-  ? '/com.snowplowanalytics.snowplow/tp2'
-  : '/t/e'
-
+export const SNOWPLOW_POST_PATH = '/t/e'
 export const SNOWPLOW_COLLECTOR_URL = 'd.getpocket.com'
 export const SNOWPLOW_COLLECTOR_URL_DEV = 'com-getpocket-prod1.mini.snplow.net'
 export const SNOWPLOW_COLLECTOR = process.env.SHOW_DEV === 'included'


### PR DESCRIPTION
## Goal

Remove custom post path that we were using for dev environments. 

## To Do:

- [x] Remove custom dev path

## Implementation Decisions

Doing this based off Kenny's note in Slack:
https://pocket.slack.com/archives/CQKRXK2G6/p1630615067004600

![snow](https://user-images.githubusercontent.com/1273879/131914597-421e27aa-499c-4d28-ba86-602cba95cfc6.gif)
