### PR TITLE
fix(home): prefer syndicated article publisher

### DIFF
--- a/src/common/api/home.js
+++ b/src/common/api/home.js
@@ -113,7 +113,7 @@ function displayThumbnail({ item, curatedInfo }) {
  * @returns {string} The best text to display as the publisher of this item
  */
 function displayPublisher({ item, publisher }) {
-  return item.domainMetadata?.name || publisher
+  return item?.syndicatedArticle?.publisher?.name || item.domainMetadata?.name || publisher
 }
 
 /** EXCERPT


### PR DESCRIPTION
## Goal

We would like to have syndicated content show original publisher

## To Do:

- [x] Update deriver to prefer syndicated article metadata

![screen_shot_2021-09-15_at_10 47 23_am](https://user-images.githubusercontent.com/16119672/133483860-56e4fba2-1728-4a14-a4be-949060596fe4.png)
