### PR TITLE
fix(collections): updating raw //

### DIFF
--- a/src/connectors/global-nav/global-nav.js
+++ b/src/connectors/global-nav/global-nav.js
@@ -67,12 +67,12 @@ const GlobalNav = ({ selectedLink: selected, subset, tag }) => {
   const isPremium = useSelector((state) => parseInt(state?.user?.premium_status, 10) === 1 || false)
   const isLoggedIn = useSelector((state) => !!state.user.auth)
   const retrievedAvatar = useSelector((state) => state?.user?.profile?.avatar_url)
-  const pocketLogoOutboundUrl = isLoggedIn ? '/my-list' : '//getpocket.com'
+  const pocketLogoOutboundUrl = isLoggedIn ? '/my-list' : 'https://getpocket.com'
 
   const myListFlyawayReady = useSelector((state) => state.onboarding.homeFlyawayMyList)
   const saveFlyawayStatus = useSelector((state) => state.onboarding.homeFlyawaySave)
   const saveFlyawayDismissed = saveFlyawayStatus === false
-  const showOnboardingHighlight = (saveFlyawayDismissed && myListFlyawayReady)
+  const showOnboardingHighlight = saveFlyawayDismissed && myListFlyawayReady
 
   const featureState = useSelector((state) => state.features)
   const showLab = featureFlagActive({ flag: 'lab', featureState })


### PR DESCRIPTION
## Goal

Even though this is valid, nextJS complains about it in earnest.  Since we convert to https:// on the server anyway there is no harm in being explicit.

## Real goal
Force a rebuild so collections unbreak

## To Do:

- [x] Explicit `https://` in global nav
- [x] SNEAKY: force a rebuild

