### PR TITLE
feat(account): adding account page /w side nav scaffolding

### DIFF
--- a/src/components/account/account.js
+++ b/src/components/account/account.js
@@ -1,0 +1,38 @@
+import { css } from 'linaria'
+
+export const accountStyles = css`
+  h1,
+  h2,
+  h3,
+  h4 {
+    grid-column: 1/-1;
+    font-family: var(--fontSansSerif);
+    line-height: 1.25;
+    margin-bottom: 0.5rem;
+    color: var(--color-textPrimary);
+  }
+  h1 {
+    font-size: 2.5rem;
+    font-weight: 600;
+  }
+  h2 {
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  h4 {
+    font-size: 1.125rem;
+    font-weight: 400;
+    color: var(--color-textSecondary);
+  }
+
+  section {
+    padding: 3rem 0;
+    border-bottom: var(--dividerStyle);
+    &:first-of-type {
+      padding-top: 0;
+    }
+    &:last-of-type {
+      border: none;
+    }
+  }
+`

--- a/src/components/side-nav/account.js
+++ b/src/components/side-nav/account.js
@@ -1,0 +1,9 @@
+import { sideNavHeader } from './side-nav'
+
+export function AccountSideNav() {
+  return (
+    <>
+      <div className={sideNavHeader}></div>
+    </>
+  )
+}

--- a/src/components/side-nav/filters.js
+++ b/src/components/side-nav/filters.js
@@ -10,26 +10,16 @@ import { VideoIcon } from '@pocket/web-ui'
 
 import { sideNavHeader } from './side-nav'
 
-export function FiltersSideNav({
-  subActive,
-  pinnedTags,
-  clickEvent
-}) {
+export function FiltersSideNav({ subActive, pinned, clickEvent }) {
   const { t } = useTranslation()
 
   return (
     <>
-      <div className={sideNavHeader}>
-        {t('nav:filters', 'Filters')}
-      </div>
+      <div className={sideNavHeader}>{t('nav:filters', 'Filters')}</div>
 
       <Link href="/my-list/archive">
-        <button
-          className={subActive('archive')}
-          onClick={clickEvent}
-          data-cy="side-nav-archive">
-          <ArchiveIcon className="side-nav-icon" />{' '}
-          {t('nav:archive', 'Archive')}
+        <button className={subActive('archive')} onClick={clickEvent} data-cy="side-nav-archive">
+          <ArchiveIcon className="side-nav-icon" /> {t('nav:archive', 'Archive')}
         </button>
       </Link>
 
@@ -38,8 +28,7 @@ export function FiltersSideNav({
           className={subActive('favorites')}
           onClick={clickEvent}
           data-cy="side-nav-favorites">
-          <FavoriteIcon className="side-nav-icon" />{' '}
-          {t('nav:favorites', 'Favorites')}
+          <FavoriteIcon className="side-nav-icon" /> {t('nav:favorites', 'Favorites')}
         </button>
       </Link>
 
@@ -48,49 +37,36 @@ export function FiltersSideNav({
           className={subActive('highlights')}
           onClick={clickEvent}
           data-cy="side-nav-highlights">
-          <HighlightIcon className="side-nav-icon" />{' '}
-          {t('nav:highlights', 'Highlights')}
+          <HighlightIcon className="side-nav-icon" /> {t('nav:highlights', 'Highlights')}
         </button>
       </Link>
 
       <Link href="/my-list/articles">
-        <button
-          className={subActive('articles')}
-          onClick={clickEvent}
-          data-cy="side-nav-articles">
-          <ArticleIcon className="side-nav-icon" />{' '}
-          {t('nav:articles', 'Articles')}
+        <button className={subActive('articles')} onClick={clickEvent} data-cy="side-nav-articles">
+          <ArticleIcon className="side-nav-icon" /> {t('nav:articles', 'Articles')}
         </button>
       </Link>
 
       <Link href="/my-list/videos">
-        <button
-          className={subActive('videos')}
-          onClick={clickEvent}
-          data-cy="side-nav-videos">
-          <VideoIcon className="side-nav-icon" />{' '}
-          {t('nav:videos', 'Videos')}
+        <button className={subActive('videos')} onClick={clickEvent} data-cy="side-nav-videos">
+          <VideoIcon className="side-nav-icon" /> {t('nav:videos', 'Videos')}
         </button>
       </Link>
-      <div className={sideNavHeader}>
-        {t('nav:tags', 'Tags')}
-      </div>
+      <div className={sideNavHeader}>{t('nav:tags', 'Tags')}</div>
       <Link href="/my-list/tags">
-        <button
-          className={subActive('tag')}
-          onClick={clickEvent}
-          data-cy="side-nav-all-tags">
-          <TagIcon className="side-nav-icon" />{' '}
-          {t('nav:all-tags', 'All Tags')}
+        <button className={subActive('tag')} onClick={clickEvent} data-cy="side-nav-all-tags">
+          <TagIcon className="side-nav-icon" /> {t('nav:all-tags', 'All Tags')}
         </button>
       </Link>
-      {pinnedTags.length
-        ? pinnedTags.map((tag) => (
+      {pinned.length
+        ? pinned.map((tag) => (
             <Link href={`/my-list/tags/${encodeURIComponent(tag)}`} key={tag}>
               <button
                 className={subActive(tag, true)}
                 onClick={clickEvent}
-                data-cy={`side-nav-tags-${tag}`}>{tag}</button>
+                data-cy={`side-nav-tags-${tag}`}>
+                {tag}
+              </button>
             </Link>
           ))
         : null}

--- a/src/components/side-nav/side-nav.js
+++ b/src/components/side-nav/side-nav.js
@@ -13,6 +13,7 @@ import { useInView } from 'react-intersection-observer'
 
 import { FiltersSideNav } from './filters'
 import { TopicsSideNav } from './topics'
+import { AccountSideNav } from './account'
 import { BookmarkIcon } from './bookmark-icon'
 
 export const sideNavWrapper = css`
@@ -141,15 +142,7 @@ export const sideNavItem = css`
   }
 `
 
-export function SideNav({
-  subset,
-  tag,
-  pinnedTags,
-  pinnedTopics,
-  isDisabled,
-  newSaveCount,
-  trackMenuClick
-}) {
+export function SideNav({ type, subset, tag, pinned, isDisabled, newSaveCount, trackMenuClick }) {
   const { t } = useTranslation()
 
   const [ref, inView] = useInView({ threshold: 0.5 })
@@ -161,16 +154,16 @@ export function SideNav({
     return `${sideNavItem} ${activeClass} ${tagClass}`
   }
 
-  const scrollToTop = () => {
-    window.scroll({
-      top: 0,
-      left: 0
-    })
-  }
-
+  const scrollToTop = () => window.scroll({ top: 0, left: 0 })
   const wrapperClass = cx(sideNavWrapper, 'side-nav', isDisabled && 'disabled')
-
   const clickEvent = (e) => trackMenuClick(e.target.textContent)
+
+  const navTypes = {
+    home: TopicsSideNav,
+    'my-list': FiltersSideNav,
+    account: AccountSideNav
+  }
+  const SubNav = navTypes[type]
 
   return (
     <div className={wrapperClass}>
@@ -208,15 +201,7 @@ export function SideNav({
             <CollectionsIcon className="side-nav-icon" /> {t('nav:collections', 'Collections')}
           </button>
         </Link>
-        {subset === 'home' ? (
-          <TopicsSideNav
-            subActive={subActive}
-            pinnedTopics={pinnedTopics}
-            clickEvent={clickEvent}
-          />
-        ) : (
-          <FiltersSideNav subActive={subActive} pinnedTags={pinnedTags} clickEvent={clickEvent} />
-        )}
+        {SubNav ? <SubNav subActive={subActive} pinned={pinned} clickEvent={clickEvent} /> : null}
       </nav>
       <div className="bottom-nav">
         <button

--- a/src/components/side-nav/topics.js
+++ b/src/components/side-nav/topics.js
@@ -2,25 +2,21 @@ import Link from 'next/link'
 import { Trans } from 'next-i18next'
 import { sideNavHeader } from './side-nav'
 
-export function TopicsSideNav({
-  subActive,
-  pinnedTopics,
-  clickEvent
-}) {
+export function TopicsSideNav({ subActive, pinned, clickEvent }) {
   return (
     <>
       <div className={sideNavHeader}>
         <Trans i18nKey="nav:topics">Topics</Trans>
       </div>
 
-      {pinnedTopics.length
-        ? pinnedTopics.map((topic) => (
+      {pinned.length
+        ? pinned.map((topic) => (
             <Link href={`/explore/${topic.topic_slug}?src=sidebar`} key={topic.topic_slug}>
               <button
                 data-cy={`side-nav-${topic.topic_slug}`}
                 className={subActive(topic)}
                 onClick={clickEvent}>
-                  {topic.display_name}
+                {topic.display_name}
               </button>
             </Link>
           ))

--- a/src/connectors/side-nav/side-nav.js
+++ b/src/connectors/side-nav/side-nav.js
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux'
 
 import { sendSnowplowEvent } from 'connectors/snowplow/snowplow.state'
 
-export function SideNav({ subset, isLoggedIn, tag }) {
+export function SideNav({ type, subset, isLoggedIn, tag }) {
   const dispatch = useDispatch()
 
   const flagsReady = useSelector((state) => state.features.flagsReady)
@@ -16,13 +16,20 @@ export function SideNav({ subset, isLoggedIn, tag }) {
   const trackMenuClick = (label) => dispatch(sendSnowplowEvent('side-nav', { label }))
 
   const isDisabled = appMode === 'bulk'
+
+  const pinTypes = {
+    home: pinnedTopics,
+    'my-list': pinnedTags
+  }
+  const pinned = pinTypes[type]
+
   return (
     <SideNavComponent
+      type={type}
       isDisabled={isDisabled}
       subset={subset}
       isLoggedIn={isLoggedIn}
-      pinnedTags={pinnedTags}
-      pinnedTopics={pinnedTopics}
+      pinned={pinned}
       tag={tag}
       newSaveCount={newSaveCount}
       flagsReady={flagsReady}

--- a/src/containers/account/account.js
+++ b/src/containers/account/account.js
@@ -1,0 +1,20 @@
+import Layout from 'layouts/with-sidebar'
+import { SideNav } from 'connectors/side-nav/side-nav'
+import { Toasts } from 'connectors/toasts/toast-list'
+import { useSelector } from 'react-redux'
+import { accountStyles } from 'components/account/account'
+
+export const Account = () => {
+  // Profile content
+  const isLoggedIn = useSelector((state) => !!state.user.auth)
+
+  return isLoggedIn ? (
+    <Layout title="Pocket - Account">
+      <SideNav type="account" isLoggedIn={isLoggedIn} />
+      <main className={`main ${accountStyles}`}>
+        <h1>Manage your account</h1>
+      </main>
+      <Toasts />
+    </Layout>
+  ) : null
+}

--- a/src/containers/home/home-standard.js
+++ b/src/containers/home/home-standard.js
@@ -34,7 +34,7 @@ export const HomeStandard = ({ metaData }) => {
 
   return (
     <Layout title={metaData.title} metaData={metaData}>
-      <SideNav subset="home" />
+      <SideNav type="home" />
       <main className="main">
         <HomeGreeting />
 

--- a/src/containers/messages/messages.js
+++ b/src/containers/messages/messages.js
@@ -45,7 +45,7 @@ export default function Messages() {
 
   return (
     <Layout title={`Pocket - ${t('messages:messages', 'Messages')}`}>
-      <SideNav isLoggedIn={isLoggedIn} />
+      <SideNav type="messages" isLoggedIn={isLoggedIn} />
 
       {hydrated ? (
         notifications.length || unconfirmedArray.length ? (

--- a/src/containers/my-list/my-list.js
+++ b/src/containers/my-list/my-list.js
@@ -86,16 +86,7 @@ export default function MyList(props) {
     if (initialItemsPopulated || userStatus === 'pending') return
     dispatch(appSetSection(section))
     dispatch(getMylistData(30, 0, subset, filter, tag))
-  }, [
-    userStatus,
-    initialItemsPopulated,
-    subset,
-    sortOrder,
-    filter,
-    section,
-    tag,
-    dispatch
-  ])
+  }, [userStatus, initialItemsPopulated, subset, sortOrder, filter, section, tag, dispatch])
 
   /**
    * Update list if we are navigating here from another my-list type page:
@@ -108,16 +99,7 @@ export default function MyList(props) {
     // since the last time we fetched the list (operations in other pages or apps)
     dispatch(appSetSection(section))
     dispatch(updateMyListData(since, subset, filter, tag))
-  }, [
-    routeChange,
-    initialItemsPopulated,
-    dispatch,
-    section,
-    since,
-    subset,
-    filter,
-    tag
-  ])
+  }, [routeChange, initialItemsPopulated, dispatch, section, since, subset, filter, tag])
 
   /**
    * Update list if we are navigating here from another page in the app
@@ -162,12 +144,8 @@ export default function MyList(props) {
   const Header = tag ? TagPageHeader : MyListHeader
 
   return (
-    <Layout
-      title={metaData.title}
-      metaData={metaData}
-      subset={subset}
-      tag={tag}>
-      <SideNav subset={subset} isLoggedIn={isLoggedIn} tag={tag} />
+    <Layout title={metaData.title} metaData={metaData} subset={subset} tag={tag}>
+      <SideNav type="my-list" subset={subset} isLoggedIn={isLoggedIn} tag={tag} />
 
       {shouldRender ? (
         <main className="main">
@@ -180,13 +158,10 @@ export default function MyList(props) {
                 tag={tag}
                 sortOrder={sortOrder}
                 handleNewest={handleNewest}
-                handleOldest={handleOldest} />
+                handleOldest={handleOldest}
+              />
               {items?.length ? (
-                <VirtualizedList
-                  type={type}
-                  section={section}
-                  loadMore={loadMore}
-                />
+                <VirtualizedList type={type} section={section} loadMore={loadMore} />
               ) : null}
               <DeleteModal />
               <TaggingModal />

--- a/src/containers/my-list/search-page/search-page.js
+++ b/src/containers/my-list/search-page/search-page.js
@@ -79,7 +79,7 @@ export default function Collection(props) {
 
   return (
     <Layout title={metaData.title} metaData={metaData}>
-      <SideNav subset={subset} isLoggedIn={isLoggedIn} search={query} />
+      <SideNav type="my-list" subset={subset} isLoggedIn={isLoggedIn} search={query} />
 
       {shouldRender ? (
         <main className="main">

--- a/src/containers/my-list/tags-page/tags-page.js
+++ b/src/containers/my-list/tags-page/tags-page.js
@@ -33,15 +33,11 @@ export default function TagsPage(props) {
 
       {shouldRender ? (
         <main className="main">
-          <MyListHeader subset={'tag-page'} filter={filter} title="tags" />
+          <MyListHeader type="my-list" subset={'tag-page'} filter={filter} title="tags" />
 
           {userTagsRecent ? <RecentTags taggedItems={taggedItems} /> : null}
           {userTags ? (
-            <TagList
-              userTags={userTags}
-              value={value}
-              valueChange={valueChange}
-            />
+            <TagList userTags={userTags} value={value} valueChange={valueChange} />
           ) : null}
         </main>
       ) : null}

--- a/src/containers/whats-new/whats-new.js
+++ b/src/containers/whats-new/whats-new.js
@@ -74,7 +74,7 @@ export default function Messages() {
 
   return (
     <Layout title={`Pocket - ${t('whats-new:whats-new', "What's New")}`}>
-      <SideNav isLoggedIn={isLoggedIn} />
+      <SideNav type="whats-new" isLoggedIn={isLoggedIn} />
       <main className={classNames('main', whatsNewStyles)}>
         <WhatsNewHeader title={t('whats-new:whats-new', "What's New")} />
         <Jun242021 />

--- a/src/pages/account/index.js
+++ b/src/pages/account/index.js
@@ -1,0 +1,14 @@
+import { Account } from 'containers/account/account'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { LOCALE_COMMON } from 'common/constants'
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, [...LOCALE_COMMON])),
+      authRequired: true
+    }
+  }
+}
+
+export default Account


### PR DESCRIPTION
## Goal

This is just the scaffold for account pages with a side nav.  No actual functionality here, but didn't want to create a ridiculously large PR.

## To Do:

- [x] Set up account page
- [x] Set up account container
- [x] Set up account side nav container
- [x] Update side nav to be less binary

## Implementation Decisions

For the most part this is straight forward.  The one caveat is the side nav needed to be updated.  To that end I added a side nav type and stopped overloading subset.

![giphy](https://user-images.githubusercontent.com/16119672/133667622-80cc0ca7-5cf9-444c-8135-c7f2646e0c01.gif)

