### PR TITLE
chore(eslint): add back some sane defaults

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,11 @@
 {
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true
+  },
   "extends": [
+    "eslint:recommended",
     "next/core-web-vitals",
     "prettier"
   ],
@@ -14,6 +20,16 @@
     "react/no-unescaped-entities": "off",
     "react/no-deprecated": "off",
     "@next/next/no-sync-scripts": "off",
+    "@next/next/no-img-element": "off",
+    "no-extra-boolean-cast": "off",
+    "no-unused-vars": [
+      "warn",
+      {
+        "vars": "local",
+        "args": "after-used",
+        "ignoreRestSiblings": false
+      }
+    ],
     "no-console": [
       "error",
       {

--- a/src/components/reader/parsed_old/parsed.js
+++ b/src/components/reader/parsed_old/parsed.js
@@ -78,7 +78,9 @@ export class Parsed extends Component {
 
         window.scrollTo(0, top)
       }
-    } catch (error) {}
+    } catch (error) {
+      console.error(error)
+    }
   }
 
   checkPositioning(val) {


### PR DESCRIPTION
## Goal

Tiny esLint adjustments after realizing next doesn't have some of the standard recommended eslints that we use.

## To Do:

- [x] Turn off image warnings
- [x] Enable eslint recommended
- [x] Add env

