### PR TITLE
fix(syndicated): wrap bottom ad in its own section tag

### DIFF
--- a/src/containers/syndicated-article/syndicated-article.js
+++ b/src/containers/syndicated-article/syndicated-article.js
@@ -202,19 +202,28 @@ export function SyndicatedArticle({ queryParams = validParams, locale }) {
                 handlePublisherImpression={trackPublisherCTAImpression}
                 handlePublisherClick={trackPublisherCTAClick}
               />
-              <AdBelowTheFold
-                allowAds={allowAds}
-                usePersonalized={usePersonalized}
-                iabTopCategory={iabTopCategory}
-                iabSubCategory={iabSubCategory}
-                curationCategory={curationCategory}
-                legacyId={legacyId}
-              />
-
-              {!isMobileWebView ? <PocketRecs itemId={originalItemId} legacyId={legacyId} /> : null}
-              {!isMobileWebView ? <TopicsBubbles topics={topics} className="no-border" /> : null}
             </footer>
           </section>
+
+          <section>
+            <AdBelowTheFold
+              allowAds={allowAds}
+              usePersonalized={usePersonalized}
+              iabTopCategory={iabTopCategory}
+              iabSubCategory={iabSubCategory}
+              curationCategory={curationCategory}
+              legacyId={legacyId}
+            />
+          </section>
+
+          {!isMobileWebView ? (
+            <section className="content-section">
+              <footer>
+                <PocketRecs itemId={originalItemId} legacyId={legacyId} />
+                <TopicsBubbles topics={topics} className="no-border" />
+              </footer>
+            </section>
+          ) : null}
         </main>
         <Toasts />
       </ArticleLayout>


### PR DESCRIPTION
## Goal

The bottom ad was pushing the layout of the recs and topic selector into a bad place.

## To Do:

- [x] Wrap ad in its own `section` tag

## Implementation Decisions

The variable width of the bottom ad could break the layout of the bottom section. It doesn't do that if you wrap it with its own `section` tag without the `content-section` class name.