### PR TITLE
fix(home): remove similar on navigation

### DIFF
--- a/src/containers/home/home.state.js
+++ b/src/containers/home/home.state.js
@@ -52,6 +52,10 @@ import { ITEMS_ADD_SUCCESS } from 'actions'
 
 import { PINNED_TOPICS_SET } from 'actions'
 
+import { MYLIST_DATA_REQUEST } from 'actions'
+import { MYLIST_UPDATE_REQUEST } from 'actions'
+import { HYDRATE } from 'actions'
+
 /** ACTIONS
  --------------------------------------------------------------- */
 export const homeHydrate = (topicSections) => ({ type: HOME_HYDRATE, topicSections })
@@ -96,7 +100,10 @@ export const homeReducers = (state = initialState, action) => {
       return { ...state, similarRecsResolved: true }
     }
 
-    case HOME_SIMILAR_RECS_CLEAR: {
+    case HOME_SIMILAR_RECS_CLEAR:
+    case MYLIST_DATA_REQUEST:
+    case MYLIST_UPDATE_REQUEST:
+    case HYDRATE: {
       return { ...state, similarRecId: false, similarRecsResolved: false }
     }
 


### PR DESCRIPTION
## Goal

This clears similar recommendations when you navigate away.  Otherwise we can get a flash of trendsetter.

## To Do:

- [x] Add navigation myList actions to home state
- [x] Add hydration actions to home state

## Implementation Decisions
![giphy](https://user-images.githubusercontent.com/16119672/137951890-419124b0-9a0d-4557-b9b4-7953480c7070.gif)

