### PR TITLE
fix(utilities): update getpublisheddate function to return correct day of month

### DIFF
--- a/src/common/utilities/date-time/date-time.js
+++ b/src/common/utilities/date-time/date-time.js
@@ -6,7 +6,7 @@ import dayjs from 'dayjs'
  */
 export function getPublishedDate(publishedAt = null) {
   const date = new Date(publishedAt)
-  return dayjs(date).format('MMMM d, YYYY')
+  return dayjs(date).format('MMMM D, YYYY')
 }
 
 /**


### PR DESCRIPTION
## Goal

There was an issue raised in #support-frontend where published dates on syndicated article pages were displaying the day of month as 0. Let's fix it so it displays the correct day!

![giphy](https://user-images.githubusercontent.com/1273879/138757063-4f133025-435d-446a-9804-9ea496ddd185.gif)

## To Do:

- [x] fix getPublishedDate function

## Implementation Decisions

The way it was set up before was returning the day of the week (eg; Sunday, Monday, Tuesday) as a zero based array. So when it was displaying `0`, what it was actually saying was it was published on Sunday. By changing the day portion of the format from `d` to `D`, we were changing it from saying `Sunday` to the correct day of month. Here's the dayjs documentation: https://day.js.org/docs/en/display/format

Here's some example links where it was broken:
https://getpocket.com/explore/item/just-don-t-do-it-10-exercise-myths
https://getpocket.com/explore/item/why-i-m-glad-that-i-m-an-overthinker
https://getpocket.com/explore/item/mystery-of-the-wheelie-suitcase-how-gender-stereotypes-held-back-the-history-of-invention
https://getpocket.com/explore/item/how-long-does-frozen-meat-last-here-s-what-you-need-to-know-about-freezing-meat

### Old
<img width="677" alt="image" src="https://user-images.githubusercontent.com/1273879/138756748-15e91db7-687f-4cea-aafb-3dc63da25fbe.png">

### Fixed
<img width="660" alt="image" src="https://user-images.githubusercontent.com/1273879/138756924-1b710296-1945-40df-afea-1472cf7f574d.png">

