### PR TITLE
fix(waypoint): update waypoint to use 'home.release' instead of the `onboarding.release` feature flag

### DIFF
--- a/src/pages/waypoint.js
+++ b/src/pages/waypoint.js
@@ -18,6 +18,11 @@ export async function getServerSideProps({ req, locale, query, defaultLocale }) 
   // NOTE: this will redirect to my list 100% of the time on localhost
   const { user_id, birth } = response?.user || {}
 
+  // If there is no user ID, account birth date or if the users language preference
+  // that they signed up with is not EN, send them to My List.
+  // NOTE: We are currently not updating the locale to match the users
+  // language preference, so they land on My List in English
+  // and will have to use the language picker in the footer to update
   if (!user_id || !birth || locale !== defaultLocale || lang !== defaultLocale) {
     return {
       redirect: {
@@ -27,11 +32,11 @@ export async function getServerSideProps({ req, locale, query, defaultLocale }) 
     }
   }
 
+  // EN users who signed up after 08-09-2021 will be assigned to 'home.release'
+  // feature flag and therefore will be sent to Home after sign up
   const featureState = await fetchUnleashData(user_id, sess_guid, birth)
-  const onboardingDev = featureFlagActive({ flag: 'onboarding.dev', featureState })
-  const onboardingRelease = featureFlagActive({ flag: 'onboarding.release', featureState })
-  const showOnboarding = onboardingDev || onboardingRelease
-  const destination = showOnboarding ? homeLink : myListLink
+  const homeRelease = featureFlagActive({ flag: 'home.release', featureState})
+  const destination = homeRelease ? homeLink : myListLink
 
   return {
     redirect: {


### PR DESCRIPTION
## Goal
Decouple the concept of onboarding being the thing that is driving EN users to Home upon sign up to simplify and reduce confusion.


![home release](https://user-images.githubusercontent.com/2893463/142264353-20f2968e-3a6b-4621-ac38-a31dc58f93bb.png)


