### PR TITLE
fix(collection): hero images format

### DIFF
--- a/src/common/utilities/urls/urls.js
+++ b/src/common/utilities/urls/urls.js
@@ -15,14 +15,15 @@ export function urlWithPocketRedirect(url) {
  * @param {string} url Url of image we want to get from the image cache
  * @param {object} imageSize {width:value, height:value} @optional
  */
-export function getImageCacheUrl(url, imageSize) {
+export function getImageCacheUrl(url, imageSize, passedFormat) {
   if (!url) return
+  const format = passedFormat || 'jpg'
   const { width = '', height = '' } = imageSize || {}
   const resizeParam = imageSize ? `${width}x${height}` : ''
   const encodedURL = encodeURIComponent(url.replace(/'/g, '%27'))
   const urlParam = `${encodedURL}`
   const cacheURL = 'https://pocket-image-cache.com' //direct'
-  return `${cacheURL}/${resizeParam}/filters:format(jpg):extract_focal()/${urlParam}`
+  return `${cacheURL}/${resizeParam}/filters:format(${format}):extract_focal()/${urlParam}`
 }
 
 /**

--- a/src/containers/collections/collection-page.js
+++ b/src/containers/collections/collection-page.js
@@ -72,7 +72,7 @@ export function CollectionPage({ locale, queryParams = {}, slug, statusCode }) {
   const authorNames = authors?.map((author) => author.name)
   const allowAds = isPremium ? false : showAds && shouldRender && oneTrustReady
   const usePersonalized = allowAds && trackingEnabled
-  const heroImage = getImageCacheUrl(imageUrl, { width: 648 })
+  const heroImage = getImageCacheUrl(imageUrl, { width: 648 }, 'png')
 
   // const count = urls?.length
   // const saveCollectionTop = () => dispatch(saveCollection(slug))


### PR DESCRIPTION
## Goal

Hero images on collection pages have the potential for artifact on jpg compression.  Since this is for a hero on a single page, there is less concern about using a png.

## To Do:

- [x] Allow format to be passed to getImageCacheUrl while maintaining a default of jpg
- [x] Pass in png as a format 

