### PR TITLE
fix(collections): show hero image at top of page for all locales

### DIFF
--- a/src/containers/collections/collections.js
+++ b/src/containers/collections/collections.js
@@ -35,7 +35,7 @@ export default function Collections({ locale }) {
 
   const showEoyCollections = locale !== 'de'
   const startingOffset = showEoyCollections ? 0 : 5
-  const useHero = showEoyCollections
+  const useHero = true
 
   return (
     <Layout title={metaData.title} metaData={metaData} canonical={canonical} forceWebView={true}>


### PR DESCRIPTION
## Goal

Germany was excluded from fancy hero images in the top lockup.  This fixes that by request from Carolyn

## To Do:

- [x] Set hero to true for all locales
