### PR TITLE
fix(sentry): turn back on sentry

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -11,7 +11,7 @@ Sentry.init({
   dsn: SENTRY_DSN || 'https://cc3aea2dd5ca4aefb5a18c671a229237@o28549.ingest.sentry.io/5436250',
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 0,
-  sampleRate: 0,
+  sampleRate: 0.5,
   beforeSend(event, hint) {
     const error = hint.originalException
 

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -10,7 +10,7 @@ Sentry.init({
   dsn: SENTRY_DSN || 'https://cc3aea2dd5ca4aefb5a18c671a229237@o28549.ingest.sentry.io/5436250',
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 0,
-  sampleRate: 0,
+  sampleRate: 0.5,
   whitelistUrls: [/https:\/\/(.+)?getpocket\.com/],
   beforeSend(event, hint) {
     const error = hint.originalException


### PR DESCRIPTION
## Goal

In https://github.com/Pocket/web-client/pull/549 I meant to only turn off tracing/transactions, but upon sentry inspection today I accidentally turned off sentry errors

## To Do:

- [x] Turn back on sentry errors

## Implementation Decisions

![3qFe](https://user-images.githubusercontent.com/1010384/145065977-dd04628b-6972-49bf-a795-16aeea6a37ae.gif)