### PR TITLE
fix(syndicated): ensure query params are passed to page

### DIFF
--- a/src/pages/discover/item/[slug].js
+++ b/src/pages/discover/item/[slug].js
@@ -10,7 +10,7 @@ export const getServerSideProps = wrapper.getServerSideProps(
   (store) =>
     async ({ query, res, req, locale }) => {
       const { dispatch, sagaTask } = store
-      const { slug } = query
+      const { slug, ...queryParams } = query
 
       // Hydrating initial state with an async request. This will block the
       // page from loading. Do this for SEO/crawler purposes
@@ -36,7 +36,11 @@ export const getServerSideProps = wrapper.getServerSideProps(
       await sagaTask.toPromise()
 
       return {
-        props: { ...(await serverSideTranslations(locale, [...LOCALE_COMMON])), locale }
+        props: {
+          ...(await serverSideTranslations(locale, [...LOCALE_COMMON])),
+          locale,
+          queryParams
+        }
       }
     }
 )


### PR DESCRIPTION
## Goal

Query params weren't being passed down to the syndicated article page. This prevented the `mobile_web_view` and `premium_user` from hiding the appropriate content

## To Do:

- [x] Pass through the query params

## Implementation Decisions

Just grabbing it from the `query` and passing it along...