### PR TITLE
fix(account): add impression to premium button on account settings page

### DIFF
--- a/src/components/account/premium/premium.js
+++ b/src/components/account/premium/premium.js
@@ -1,6 +1,8 @@
 import { css } from 'linaria'
 import { Button } from '@pocket/web-ui'
 import { useTranslation } from 'next-i18next'
+import { useInView } from 'react-intersection-observer'
+import { useEffect } from 'react'
 
 const premiumStyle = css`
   h2 {
@@ -21,8 +23,13 @@ const premiumStyle = css`
   }
 `
 
-export const Premium = ({ isPremium }) => {
+export const Premium = ({ isPremium, onPremiumImpression }) => {
   const { t } = useTranslation()
+
+  // Fire when item is in view
+  const [viewRef, inView] = useInView({ triggerOnce: true, threshold: 0.5 })
+  useEffect(() => onPremiumImpression(inView), [inView, onPremiumImpression])
+
   return (
     <section className={premiumStyle}>
       <h2>{t('account:premium', 'Premium')}</h2>
@@ -44,7 +51,7 @@ export const Premium = ({ isPremium }) => {
               <Button variant="brand">{t('account:premium-manage', 'Manage Subscription')}</Button>
             </a>
           ) : (
-            <a href="https://getpocket.com/premium">
+            <a href="https://getpocket.com/premium" ref={viewRef}>
               <Button variant="brand">
                 {t('account:premium-subscribe', 'Get Pocket Premium')}
               </Button>

--- a/src/components/global-nav/account/global-nav-account.js
+++ b/src/components/global-nav/account/global-nav-account.js
@@ -307,7 +307,7 @@ const GlobalNavAccount = ({
         </PopupMenuGroup>
         <PopupMenuGroup>
           <PopupMenuItem
-            href="https://getpocket.com/account?src=navbar"
+            href="/account?src=navbar"
             id="account-menu-manage-account-link"
             onClick={handleManageAccountCase}
             data-cy="account-menu-manage-account-link">

--- a/src/connectors/snowplow/actions/account.js
+++ b/src/connectors/snowplow/actions/account.js
@@ -1,0 +1,11 @@
+export const accountActions = {
+  'account.premium.upsell': {
+    eventType: 'impression',
+    entityTypes: ['ui'],
+    eventData: {
+      component: 'ui',
+      uiType: 'button'
+    },
+    description: 'Upgrade button at the top of the account settings page'
+  }
+}

--- a/src/connectors/snowplow/actions/index.js
+++ b/src/connectors/snowplow/actions/index.js
@@ -1,3 +1,4 @@
+import { accountActions } from './account'
 import { collectionsActions } from './collections'
 import { discoverActions } from './discover'
 import { globalNavActions } from './global-nav'
@@ -11,6 +12,7 @@ import { sideNavActions } from './side-nav'
 import { syndicatedArticleActions } from './syndicated-article'
 
 export const analyticsActions = {
+  ...accountActions,
   ...collectionsActions,
   ...discoverActions,
   ...globalNavActions,

--- a/src/containers/account/account.js
+++ b/src/containers/account/account.js
@@ -1,7 +1,7 @@
 import Layout from 'layouts/with-sidebar'
 import { SideNav } from 'connectors/side-nav/side-nav'
 import { Toasts } from 'connectors/toasts/toast-list'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import { accountStyles } from 'components/account/account'
 import { Premium } from 'components/account/premium/premium'
 import { Profile } from 'containers/account/profile/profile'
@@ -11,19 +11,25 @@ import { ConnectedServices } from 'containers/account/connections/connections'
 import { RSSFeeds } from 'containers/account/rss/rss'
 import { Privacy } from 'containers/account/privacy/privacy'
 import { useTranslation } from 'next-i18next'
+import { sendSnowplowEvent } from 'connectors/snowplow/snowplow.state'
 
 export const Account = () => {
+  const dispatch = useDispatch()
+
   // Profile content
   const isLoggedIn = useSelector((state) => !!state.user.auth)
   const isPremium = useSelector((state) => state.user.premium_status === '1')
   const { t } = useTranslation()
+
+  const onImpression = () => dispatch(sendSnowplowEvent('account.premium.upsell'))
+  const onPremiumImpression = (inView) => (inView ? onImpression() : null)
 
   return isLoggedIn ? (
     <Layout title="Pocket - Account">
       <SideNav type="account" isLoggedIn={isLoggedIn} />
       <main className={`main ${accountStyles}`}>
         <h1>{t('account:manage-your-account', 'Manage your account')}</h1>
-        <Premium isPremium={isPremium} />
+        <Premium isPremium={isPremium} onPremiumImpression={onPremiumImpression}/>
         <Profile />
         <Email />
         <Notifications />


### PR DESCRIPTION
## Goal

A request came in to #support-frontend asking if we could add an impression to this button. It was easy enough so I knocked it out 👊 

## To Do:

- [x] Add event to `actions`
- [x] Fire event on button impression
- [x] Update Manage Account link in dropdown to be root relative

## Implementation Decisions

Fairly simple pattern that we've established elsewhere 