### PR TITLE
fix(reader): missing itemId in annotation actions

### DIFF
--- a/src/containers/read/read.state.js
+++ b/src/containers/read/read.state.js
@@ -50,8 +50,8 @@ import { HYDRATE } from 'actions'
 /** ACTIONS
  --------------------------------------------------------------- */
 export const itemDataRequest = (itemId) => ({ type: ARTICLE_ITEM_REQUEST, itemId }) //prettier-ignore
-export const saveAnnotation = ({ item_id, quote, patch }) => ({ type: ANNOTATION_SAVE_REQUEST, item_id, quote, patch }) //prettier-ignore
-export const deleteAnnotation = ({ item_id, annotation_id }) => ({ type: ANNOTATION_DELETE_REQUEST, item_id, annotation_id }) //prettier-ignore
+export const saveAnnotation = ({ itemId, quote, patch }) => ({ type: ANNOTATION_SAVE_REQUEST, item_id: itemId, quote, patch }) //prettier-ignore
+export const deleteAnnotation = ({ itemId, annotation_id }) => ({ type: ANNOTATION_DELETE_REQUEST, item_id: itemId, annotation_id }) //prettier-ignore
 export const updateLineHeight = (lineHeight) => ({ type: UPDATE_LINE_HEIGHT, lineHeight }) //prettier-ignore
 export const updateColumnWidth = (columnWidth) => ({ type: UPDATE_COLUMN_WIDTH, columnWidth }) //prettier-ignore
 export const updateFontSize = (fontSize) => ({ type: UPDATE_FONT_SIZE, fontSize }) //prettier-ignore


### PR DESCRIPTION
## Goal

Annotations/.highlights were not saving properly.

## To Do:

- [x] transform itemId to item_id for the v3 actions

## Implementation Decisions

The dangers of living in two different worlds. Item Actions on v3 expect `item_id` graph uses `itemId`. 

![giphy-4](https://user-images.githubusercontent.com/16119672/150405657-1b11c423-f388-4ffa-8526-99825f79405c.gif)

