### PR TITLE
fix(deriveReccit): include sort_id when we modernize item - FRONT-1574

### DIFF
--- a/src/common/api/derivers/item.js
+++ b/src/common/api/derivers/item.js
@@ -104,10 +104,11 @@ export function deriveRecommendation(
 }
 
 export function deriveReccit(recommendation) {
-  const { item: passedItem, ...rest } = recommendation //eslint-disable-line no-unused-vars
+  const { item: passedItem, sort_id, ...rest } = recommendation //eslint-disable-line no-unused-vars
   const {
-    node: { item }
-  } = modernizeItem(passedItem)
+    node: { item },
+  } = modernizeItem({...passedItem, sort_id})
+
   const derivedItem = deriveItem({ item, utmId: 'pocket_rec' })
 
   return derivedItem


### PR DESCRIPTION
## Goal

Fix issue where recommendations at the bottom of the Reader were not sorted correctly

## To Do:

- [x] grab `sort_id` from the edge data and pass it to `modernizeItem` so it gets assigned correctly

