### PR TITLE
fix(waypoint): add check for supportedLocale

### DIFF
--- a/src/pages/waypoint.js
+++ b/src/pages/waypoint.js
@@ -8,7 +8,8 @@ export default function Waypoint() {}
 export async function getServerSideProps({ req, locale, query, defaultLocale, locales }) {
   // returns first two letters of browser defined language settings
   const lang = req.headers['accept-language'].toString().substring(0, 2)
-  const langPrefix = lang !== defaultLocale && locales.includes(lang) ? `/${lang}` : ''
+  const supportedLocale = locales.includes(lang)
+  const langPrefix = lang !== defaultLocale && supportedLocale ? `/${lang}` : ''
   const authToken = query?.access_token || false
   delete query.access_token
 
@@ -21,7 +22,7 @@ export async function getServerSideProps({ req, locale, query, defaultLocale, lo
   // NOTE: this will redirect to my list 100% of the time on localhost
   const { user_id, birth } = response?.user || {}
 
-  if (!user_id || !birth || locale !== defaultLocale || lang !== defaultLocale) {
+  if (!user_id || !birth || locale !== defaultLocale || lang !== defaultLocale && supportedLocale) {
     return {
       redirect: {
         permanent: false,


### PR DESCRIPTION
## Goal

Currently, users with a locale that is not in Pocket's list of supported locales get assigned to the `onboarding.rollout` test, but they were still landing on My List instead of Home on sign up. This makes it so the check to send them to My List also checks that the locale is supported by Pocket. If it is not, they go into the `home.release` check, which checks for account birth and routes them accordingly, so new users with an unsupported locale will land on Home.

## To Do:

- [x] Add check for supported locale

![7e3e968b-62e2-4fa5-a51f-bf41d036a83e_text](https://user-images.githubusercontent.com/2893463/151456798-74d9d3ea-cd20-46cf-8a61-e00b0033f8e1.gif)

