### PR TITLE
fix(shorcuts): update open_url to externalUrl per new item store [FRONT-1588]

### DIFF
--- a/src/connectors/shortcuts/shortcuts.state.js
+++ b/src/connectors/shortcuts/shortcuts.state.js
@@ -341,8 +341,8 @@ function* shortcutViewOriginal() {
   const item = yield select(getItem, selectedId)
   if (!item) return
 
-  const { open_url } = item
-  if (open_url) yield call(window.open, open_url, '_blank')
+  const { externalUrl } = item
+  if (externalUrl) yield call(window.open, externalUrl, '_blank')
 }
 
 function* shortcutDeleteItem({ appMode }) {


### PR DESCRIPTION
## Goal

The `o` shortcut in Reader view wasn't working anymore

## To Do:

- [x] update `open_url` to `externalUrl`

## Implementation Decisions

We don't have `open_url` anymore with the way our new derivers work.