### PR TITLE
fix(snowplow): fix broken content entities on bulk edit, save on collections, and collection impressions

### DIFF
--- a/src/connectors/global-nav/global-nav-bulk-edit.js
+++ b/src/connectors/global-nav/global-nav-bulk-edit.js
@@ -27,7 +27,7 @@ function GlobalNavBulkEditConnected({ onClose }) {
   const buildBulkForAnalytics = () => {
     return bulkItems.map(item => ({
       id: item.id,
-      url: item.save_url,
+      url: item.saveUrl,
       position: item.position
     }))
   }

--- a/src/connectors/item-card/collection/story-card.js
+++ b/src/connectors/item-card/collection/story-card.js
@@ -17,7 +17,7 @@ export function ItemCard({ id, cardShape, className, showExcerpt = false, positi
   const item = useSelector((state) => state.collectionStoriesById[id])
   const { itemId, readUrl, externalUrl, openExternal } = item
 
-  const impressionFired = useSelector((state) => state.analytics.impressions.includes(externalUrl))
+  const impressionFired = useSelector((state) => state.analytics.impressions.includes(itemId))
 
   if (!item) return null
 

--- a/src/containers/collections/collection-page.js
+++ b/src/containers/collections/collection-page.js
@@ -125,6 +125,7 @@ export function CollectionPage({ locale, queryParams = {}, slug, statusCode }) {
               isAuthenticated={isAuthenticated}
               saveAction={saveAction}
               saveStatus={pageSaveStatus}
+              url={url}
             />
           </header>
         </section>
@@ -198,6 +199,7 @@ export function CollectionPage({ locale, queryParams = {}, slug, statusCode }) {
               isAuthenticated={isAuthenticated}
               saveAction={saveAction}
               saveStatus={pageSaveStatus}
+              url={url}
             />
 
             <AdBelowTheFold


### PR DESCRIPTION
## Goal

Fixing some broken `content` entity errors on various snowplow events

## To Do:

- [x] Fix broken impression events on Cards on Collection Story page
- [x] Fix broken Save engagement events on Collection Story page
- [x] Fix url on Bulk Edit events

## Implementation Decisions

Sorted through the spreadsheet of DOOOOOOM

![the-doom-song](https://user-images.githubusercontent.com/1273879/153306667-b2e41efe-92b5-40c4-aefa-80f315e5e87b.gif)