### PR TITLE
fix(onetrust): use tracking cookie to set googletag values [FRONT-1628]

### DIFF
--- a/src/connectors/one-trust/one-trust.state.js
+++ b/src/connectors/one-trust/one-trust.state.js
@@ -25,10 +25,29 @@ let OptanonAnalyticsCookie
 // This function is called automatically by OneTrusts script
 global.OptanonWrapper = () => {
   const onetrustCookies = arrayToObject(updateCategories(global.OptanonActiveGroups), 'name')
-  const analyticsEnabled = onetrustCookies.analytics.enabled
+  const analyticsEnabled = onetrustCookies?.analytics.enabled
+  const trackingEnabled = onetrustCookies?.tracking.enabled
 
   if (OptanonAnalyticsCookie && !analyticsEnabled) return window.location.reload()
   OptanonAnalyticsCookie = analyticsEnabled
+
+  const personalized = trackingEnabled ? 0 : 1
+  checkPersonalizedAds(personalized)
+}
+
+const checkPersonalizedAds = (personalized) => {
+  if (!global.googletag) return // Google ads aren't on page
+
+  if (global.googletag.apiReady) {
+    global.googletag.pubads().disableInitialLoad()
+    global.googletag.pubads().setRequestNonPersonalizedAds(personalized)
+    global.googletag.pubads().refresh()
+  }
+  else {
+    setTimeout(() => {
+      checkPersonalizedAds(personalized)
+    }, 50)
+  }
 }
 
 export const updateOnetrustData = (groups) => ({ type: ONE_TRUST_DATA, groups })


### PR DESCRIPTION
## Goal

Google ads and tracking and one trust and it all sucks. Basically we want to set some google ads parameters depending on One Trust

## To Do:

- [x] Add check personalized ads function to OptanonWrapper

## Implementation Decisions

The code they gave us was trash, but it conveyed the idea. When the `OptanonWrapper` function is call we should then use that cookie value to determine if we should serve personalized ads. They had a loop in their code which was... rough. Their code also didn't account for pages that didn't have google ads so it would loop foreverrrrrr. 

Here's what they gave me:
```
function OnetrustAdsConsent(){
    if(googletag.apiReady){
        
        googletag.pubads().disableInitialLoad();
        
        if(OptanonActiveGroups.match(/,C0004,/)){
            googletag.pubads().setRequestNonPersonalizedAds(0);
            googletag.pubads().refresh();
           }
        else{
            googletag.pubads().setRequestNonPersonalizedAds(1);
            googletag.pubads().refresh();
        }
    }
    else{
        OnetrustAdsConsent();
    }   
}
function OptanonWrapper(){
    OnetrustAdsConsent();
}
```