### PR TITLE
fix(snowplow): adding generic shortcuts related engagement event [FRONT-1653]

### DIFF
--- a/src/components/reader/nav.js
+++ b/src/components/reader/nav.js
@@ -26,6 +26,7 @@ import {
 import { ProgressBar } from 'components/progress-bar/progress-bar'
 import { useTranslation } from 'next-i18next'
 import Mousetrap from 'mousetrap'
+import { sendSnowplowEvent } from 'connectors/snowplow/snowplow.state'
 
 const headerStyle = css`
   position: fixed;
@@ -136,6 +137,9 @@ export const ReaderNav = ({
   const setLineHeight = (val) => dispatch(updateLineHeight(val))
   const setColumnWidth = (val) => dispatch(updateColumnWidth(val))
   const goBack = () => {
+    const analyticsData = { label: 'Back to List', value: 'b' }
+    dispatch(sendSnowplowEvent('shortcut', analyticsData))
+
     if (window.history.length > 1) return window.history.go(-1)
     document.location.href = '/my-list'
   }

--- a/src/connectors/shortcuts/shortcuts.js
+++ b/src/connectors/shortcuts/shortcuts.js
@@ -6,6 +6,7 @@ import { ShortCutsView } from 'components/shortcuts-view/shortcuts-view'
 import { listShortcuts } from './shortcuts.state'
 import { readerShortcuts } from './shortcuts.state'
 import { itemActions } from './shortcuts.state'
+import { sendSnowplowEvent } from 'connectors/snowplow/snowplow.state'
 
 import { closeHelpOverlay } from './shortcuts.state'
 
@@ -24,12 +25,14 @@ export function Shortcuts() {
     const shortCuts = [...listShortcuts, ...itemActions, ...readerShortcuts]
     Mousetrap.addKeycodes({ 173: '-' }) // For FF hyphen code
 
-    shortCuts.forEach(({ keys, action, omit, prevent, premium }) => {
+    shortCuts.forEach(({ keys, action, omit, prevent, premium, keyCopy, copy }) => {
       if (omit) return // We want in the list but not bound
       if (premium && !isPremium) return // It is a premium feature
       const actionPayload = action({ router, appMode })
+      const analyticsData = { label: copy, value: keyCopy }
       const boundAction = (event) => {
         if (prevent) event.preventDefault()
+        dispatch(sendSnowplowEvent('shortcut', analyticsData))
         dispatch(actionPayload)
       }
       Mousetrap.bind(keys, boundAction)

--- a/src/connectors/snowplow/actions/index.js
+++ b/src/connectors/snowplow/actions/index.js
@@ -8,6 +8,7 @@ import { myListActions } from './my-list'
 import { onboardingActions } from './onboarding'
 import { profileActions } from './profile'
 import { readerActions } from './reader'
+import { shortcutActions } from './shortcuts'
 import { sideNavActions } from './side-nav'
 import { syndicatedArticleActions } from './syndicated-article'
 
@@ -21,6 +22,7 @@ export const analyticsActions = {
   ...myListActions,
   ...onboardingActions,
   ...profileActions,
+  ...shortcutActions,
   ...readerActions,
   ...sideNavActions,
   ...syndicatedArticleActions

--- a/src/connectors/snowplow/actions/shortcuts.js
+++ b/src/connectors/snowplow/actions/shortcuts.js
@@ -1,0 +1,10 @@
+export const shortcutActions = {
+  'shortcut': {
+    eventType: 'engagement',
+    entityTypes: ['ui'],
+    eventData: {
+      uiType: 'button',
+    },
+    expects: ['value', 'label']
+  }
+}


### PR DESCRIPTION
## Goal

Let's learn how our users are using our keyboard shortcuts!

## To Do:

- [x] Add new `shortcuts` actions
- [x] Add generic event within shortcuts
- [x] Handle generic event for shortcuts not kept within the shortcuts file (Reader Nav)

## Implementation Decisions

Added a simple event to track which ones our users are using. The plan is to review the data from these events in a month's time to determine whether we need more fidelity into these events.

![shortcut](https://user-images.githubusercontent.com/1273879/155598457-ebcbeee4-6685-47a7-9d42-59537e709823.gif)