### PR TITLE
fix(onetrust): remove refresh of google ads

### DIFF
--- a/src/connectors/one-trust/one-trust.state.js
+++ b/src/connectors/one-trust/one-trust.state.js
@@ -41,7 +41,6 @@ const checkPersonalizedAds = (personalized) => {
   if (global.googletag.apiReady) {
     global.googletag.pubads().disableInitialLoad()
     global.googletag.pubads().setRequestNonPersonalizedAds(personalized)
-    global.googletag.pubads().refresh()
   }
   else {
     setTimeout(() => {


### PR DESCRIPTION
## Goal

Programmatic asked us to remove this line

## To Do:

- [x] Remove the line

## Implementation Decisions

I did it, it's done. I barely thought about it.

Sidenote: There's another refresh in the code-base, we may need to do some back and forth