### PR TITLE
chore(waypoint): remove unused query parameters

### DIFF
--- a/src/pages/waypoint.js
+++ b/src/pages/waypoint.js
@@ -12,8 +12,11 @@ export async function getServerSideProps({ req, locale, query, defaultLocale, lo
     const lang = req.headers['accept-language'].toString().substring(0, 2)
     const supportedLocale = locales.includes(lang)
     const langPrefix = lang !== defaultLocale && supportedLocale ? `/${lang}` : ''
-    const authToken = query?.access_token || false
-    delete query.access_token
+
+    // query parameters returned after auth that are currently not used.
+    // remove from the list of query parameters
+    const unusedQueryParams = ['access_token', 'id', 'guid', 'type']
+    unusedQueryParams.forEach(param => delete query[param])
 
     const myListLink = queryString.stringifyUrl({ url: `${langPrefix}/my-list`, query })
     const homeLink = queryString.stringifyUrl({ url: '/home', query })


### PR DESCRIPTION
## Goal
Remove query parameters that are not used by the web-client when `/waypoint` is visited.

## To Do:

- [x] Remove `id` from `query`
- [x] Remove `guid` from `query`
- [x] Remove `type` from `query`

## Implementation Decisions
Refactored to remove all unused parameters in a loop
![waypoint-redirect](https://user-images.githubusercontent.com/10347996/156053829-97286b44-c613-4378-b665-cd992e3d8d9e.gif)

