### PR TITLE
fix(snowplow): ensure settings value sent is string

### DIFF
--- a/src/containers/read/read.state.js
+++ b/src/containers/read/read.state.js
@@ -302,7 +302,7 @@ function* saveDisplaySettings({ type, ...settings }) {
 
   const identifier = 'reader.display'
   const data = Object.keys(settings).map((label) => ({
-    value: settings[label],
+    value: settings[label]?.toString(),
     label
   }))
   yield put({ type: SNOWPLOW_SEND_EVENT, identifier, data })


### PR DESCRIPTION
## Goal

Any value sent to as a `ui` entity must be a string

## To Do:

- [x] Guarantee the reader setting sent is a string

## Implementation Decisions

There was a bug in the display settings snowplow updated yesterday. This fixes it!