### PR TITLE
fix(snowplow): fix reader back shortcut

### DIFF
--- a/src/components/reader/nav.js
+++ b/src/components/reader/nav.js
@@ -140,6 +140,10 @@ export const ReaderNav = ({
     if (window.history.length > 1) return window.history.go(-1)
     document.location.href = '/my-list'
   }
+  const clickGoBack = () => {
+    dispatch(sendSnowplowEvent('reader.goback'))
+    goBack()
+  }
   const shortcutGoBack = () => {
     const analyticsData = { label: 'Back to List', value: 'b' }
     dispatch(sendSnowplowEvent('shortcut', analyticsData))
@@ -157,7 +161,7 @@ export const ReaderNav = ({
       <div className="global-nav-container">
         <nav className={navStyle}>
           <button
-            onClick={goBack}
+            onClick={clickGoBack}
             aria-label={t('nav:back-to-my-list', 'Back to My List')}
             data-tooltip={t('nav:back-to-my-list', 'Back to My List')}
             data-cy="reader-nav-go-back"

--- a/src/connectors/snowplow/actions/reader.js
+++ b/src/connectors/snowplow/actions/reader.js
@@ -159,5 +159,12 @@ export const readerActions = {
       uiType: 'button'
     },
     expects: ['value', 'label']
+  },
+  'reader.goback': {
+    eventType: 'engagement',
+    entityTypes: ['ui'],
+    eventData: {
+      uiType: 'button'
+    }
   }
 }


### PR DESCRIPTION
## Goal

This was being fired every time a user clicked the Back button instead of only when a shortcut was used.

## To Do:

- [x] Separate the shortcut analytics event from the onClick event

## Implementation Decisions

I bound the keyboard shortcut to its own function that will send the analytics event, and then call the click handler