### PR TITLE
fix(api): update get saved item query to include authors and article

### DIFF
--- a/src/common/api/index.js
+++ b/src/common/api/index.js
@@ -26,6 +26,8 @@ export { getRandomSyndicatedArticle } from './queries/get-syndicated-article'
 export { getSavedItems } from './queries/get-saved-items'
 export { searchSavedItems } from './queries/search-saved-items'
 
+export { getSavedItemByItemId } from './queries/get-saved-item-by-id'
+
 // Item Mutations
 export { itemFavorite } from './mutations/favoriteItem'
 export { itemUnFavorite } from './mutations/unfavoriteItem'

--- a/src/common/api/queries/get-saved-item-by-id.js
+++ b/src/common/api/queries/get-saved-item-by-id.js
@@ -25,6 +25,14 @@ const getSavedItemByIdQuery = gql`
         }
         item {
           ...ItemDetails
+          ... on Item {
+            article
+            authors {
+              id
+              name
+              url
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Goal

Make the query return all the same data as `v3`

## To Do:

- [x] Add authors
- [x] Add article

## Implementation Decisions

I wanted the `authors` and `article` parameter on the same level as the rest of the item data