### PR TITLE
fix(snowplow): remove invalid keys from newsletter_subscriber entity

### DIFF
--- a/src/connectors/snowplow/entities/newsletter-subscriber.js
+++ b/src/connectors/snowplow/entities/newsletter-subscriber.js
@@ -1,5 +1,11 @@
 import { getSchemaUri } from 'connectors/snowplow/snowplow.utilities'
+import { getObjectWithValidKeysOnly } from 'common/utilities'
 
+
+/**
+ * Schema information:
+ * https://console.snowplowanalytics.com/cf0fba6b-23b3-49a0-9d79-7ce18b8f9618/data-structures/2f56902d3fb80ca6f5dcb8aed41cdadac4173e2e884214917751710439ff8a09
+ */
 const NEWSLETTER_SUBSCRIBER_SCHEMA_URL = getSchemaUri('newsletter_subscriber', '1-0-2')
 
 /**
@@ -27,12 +33,12 @@ const createNewsletterSubscriberEntity = ({
   locale = 'en'
 }) => ({
   schema: NEWSLETTER_SUBSCRIBER_SCHEMA_URL,
-  data: {
+  data: getObjectWithValidKeysOnly({
     object_version: objectVersion,
     frequency,
     email,
     newsletter: `pocket_hits_${filterLocale(locale)}`
-  }
+  })
 })
 
 export default createNewsletterSubscriberEntity

--- a/src/connectors/snowplow/events/object-update.js
+++ b/src/connectors/snowplow/events/object-update.js
@@ -1,5 +1,9 @@
 import { getSchemaUri } from 'connectors/snowplow/snowplow.utilities'
 
+/**
+ * Schema information:
+ * https://console.snowplowanalytics.com/cf0fba6b-23b3-49a0-9d79-7ce18b8f9618/data-structures/a30c8f05ecf12d2b53202ed1cf161a4c578fab653f846550a20392659449dbad
+ */
 const OBJECT_UPDATE_SCHEMA_URL = getSchemaUri('object_update', '1-0-5')
 
 /**


### PR DESCRIPTION
## Goal

We need to remove the `email` field when the value is an empty string

## To Do:

- [x] Wrap entity data with `getObjectWithValidKeysOnly`
- [x] Bonus: add link to entity and event schema

## Implementation Decisions

Just reusing the handy utility function to accomplish this.