### PR TITLE
fix(highlights): create and delete highlights correctly

### DIFF
--- a/src/containers/read/legacy-reader.js
+++ b/src/containers/read/legacy-reader.js
@@ -168,7 +168,7 @@ export default function LegacyReader() {
       dispatch(sendSnowplowEvent('reader.add-highlight', analyticsInfo))
       dispatch(
         saveAnnotation({
-          id,
+          itemId,
           patch: requestAnnotationPatch(highlight),
           quote: highlight.toString()
         })
@@ -180,7 +180,7 @@ export default function LegacyReader() {
     dispatch(sendSnowplowEvent('reader.remove-highlight', analyticsInfo))
     dispatch(
       deleteAnnotation({
-        id,
+        itemId,
         annotation_id
       })
     )


### PR DESCRIPTION
## Goal

Issue: when creating a new highlight, it would not get saved properly and would disappear upon page refresh or opening the item in reader again. Also fixed highlights not deleting correctly. 

This was my bad. Stemmed from an incorrect find-and-replace.