### PR TITLE
fix(account): hide pocket hits frequency dropdown when feature flag is active - FRONT-1671

### DIFF
--- a/src/components/account/notifications/notifications.js
+++ b/src/components/account/notifications/notifications.js
@@ -1,5 +1,7 @@
 import { css } from 'linaria'
 import { useTranslation } from 'next-i18next'
+import { useSelector } from 'react-redux'
+import { featureFlagActive } from 'connectors/feature-flags/feature-flags'
 
 const notficationsStyle = css`
   padding-bottom: 3rem;
@@ -13,6 +15,8 @@ export const Notifications = ({
   onFrequencyChange
 }) => {
   const { t } = useTranslation()
+  const featureState = useSelector((state) => state.features)
+  const showPocketHits = !featureFlagActive({ flag: 'pocket-hits.disable', featureState })
 
   return (
     <section className={notficationsStyle}>
@@ -30,23 +34,27 @@ export const Notifications = ({
           onChange={onMarketingToggle}
         />
 
-        <label htmlFor="pockethits" className="flush">
-          {t('account:pocket-hits', 'Pocket Hits')}
-        </label>
-        <select value={hitsFrequency} onChange={onFrequencyChange}>
-          <option disabled>———</option>
-          <option value="daily">{t('account:pocket-hits-daily', 'Daily')}</option>
-          <option value="weekly">{t('account:pocket-hits-weekly', 'Once a week')}</option>
-          <option value="never">
-            {t('account:pocket-hits-never', 'Unsubscribe: Opt out of Pocket Hits')}
-          </option>
-        </select>
-        <div className="helperText full">
-          {t(
-            'account:pocket-hits-disclaimer',
-            'Pocket Hits is a curated newsletter showcasing the very best stories in Pocket delivered by email.'
-          )}
-        </div>
+        {showPocketHits ? (
+          <>
+            <label htmlFor="pockethits" className="flush">
+              {t('account:pocket-hits', 'Pocket Hits')}
+            </label>
+            <select value={hitsFrequency} onChange={onFrequencyChange}>
+              <option disabled>———</option>
+              <option value="daily">{t('account:pocket-hits-daily', 'Daily')}</option>
+              <option value="weekly">{t('account:pocket-hits-weekly', 'Once a week')}</option>
+              <option value="never">
+                {t('account:pocket-hits-never', 'Unsubscribe: Opt out of Pocket Hits')}
+              </option>
+            </select>
+            <div className="helperText full">
+              {t(
+                'account:pocket-hits-disclaimer',
+                'Pocket Hits is a curated newsletter showcasing the very best stories in Pocket delivered by email.'
+              )}
+            </div>
+          </>
+        ) : null}
       </div>
     </section>
   )


### PR DESCRIPTION
[Jira](https://getpocket.atlassian.net/browse/FRONT-1671)

## To Do:

- [x] Set up feature flag in unleash (it is currently disabled and we will disable it tomorrow when we get the go-ahead)
- [x] Hide Pocket Hits frequency dropdown when feature flag is active