### PR TITLE
fix(home): no longer include the recommendation entity with similar item events

### DIFF
--- a/src/connectors/snowplow/actions/home.js
+++ b/src/connectors/snowplow/actions/home.js
@@ -97,7 +97,7 @@ export const homeActions = {
   },
   'home.similar.view-original': {
     eventType: 'contentOpen',
-    entityTypes: ['content', 'recommendation', 'ui'],
+    entityTypes: ['content', 'ui'],
     eventData: {
       uiType: 'card'
     },
@@ -105,8 +105,7 @@ export const homeActions = {
       'id',
       'url',
       'position',
-      'destination',
-      'recommendationId',
+      'destination'
     ]
   },
   'home.recent.impression': {


### PR DESCRIPTION
## Goal

Mini discovered an analytics error when sending the `home.similar.view-original` event. This PR fixes it

## To Do:

- [x] Remove `recommendation` entity from the `view-original` event

## Implementation Decisions

I narrowed it down to the `recommendation` entity being included when it didn't need to since it comes from `v3`