### PR TITLE
fix(share): fix email share button

### DIFF
--- a/src/components/content-actions/article-actions.js
+++ b/src/components/content-actions/article-actions.js
@@ -116,10 +116,10 @@ function buildShareUrl(url, source) {
 
 function buildEmailUrl(shareUrl, title, excerpt) {
   const builtUrl = buildShareUrl(shareUrl, 'emailsynd')
-  const body = excerpt ? `${excerpt} — ${builtUrl}` : builtUrl
-  const url = new URL(builtUrl)
-  url.search = new URLSearchParams({ subject: title, body })
-  return `mailto:${url.href}`
+  const body = excerpt
+    ? `${excerpt} — ${encodeURIComponent(builtUrl)}`
+    : encodeURIComponent(builtUrl)
+  return `mailto:?subject=${title}&body=${body}`
 }
 
 export const ArticleActions = function ({


### PR DESCRIPTION
## Goal

Mini found a bug when testing the share buttons.

## To Do:

- [x] Hand build the URL instead of using `URLSearchParams`

## Implementation Decisions

This is simpler anyways (plus I'm pretty sure it's our least used share button)