### PR TITLE
fix(one trust): don’t pass an empty action

### DIFF
--- a/src/connectors/one-trust/one-trust.js
+++ b/src/connectors/one-trust/one-trust.js
@@ -31,7 +31,7 @@ export function PostTrustInit() {
 
   useEffect(() => {
     function checkCookies() {
-      if (global.OptanonActiveGroups !== ONETRUST_EMPTY_DEFAULT) {
+      if (global.OptanonActiveGroups && global.OptanonActiveGroups !== ONETRUST_EMPTY_DEFAULT) {
         dispatch(updateOnetrustData(global.OptanonActiveGroups))
       } else {
         setTimeout(checkCookies, 50)


### PR DESCRIPTION
## Goal

One trust had some race conditions that could cause snowplow to never load.  Likely this was also causing ads to not load as well when we were waiting for OneTrust readiness.

We were passing empty groups to  `updateOnetrustData` and the whole kit and caboodle was silently failing.

Fingers crossed this is the single point of failure and all will be right with the world in the aftermath.

## To Do:

- [x] Make sure we have a value as well as comparing it

![giphy-2](https://user-images.githubusercontent.com/16119672/168670031-cfae4957-5638-4550-bdeb-d8522bdd0a7d.gif)

