### PR TITLE
fix(home): remove similar button from recently saved [FRONT-1725]

### DIFF
--- a/src/connectors/item-card/home/card-recent-actions.js
+++ b/src/connectors/item-card/home/card-recent-actions.js
@@ -1,4 +1,5 @@
-import React from 'react'
+// Removed from Home on 5/19/22
+
 import { itemActionStyle } from 'components/item-actions/base'
 import { useSelector, useDispatch } from 'react-redux'
 import { getSimilarRecs } from 'containers/home/home.state'

--- a/src/connectors/item-card/home/card-recent.js
+++ b/src/connectors/item-card/home/card-recent.js
@@ -1,7 +1,6 @@
 import { Card } from 'components/item-card/card'
 import { useSelector, useDispatch } from 'react-redux'
 import { sendSnowplowEvent } from 'connectors/snowplow/snowplow.state'
-import { ActionsRecent } from './card-recent-actions'
 
 export const RecentCard = ({
   id,
@@ -65,7 +64,6 @@ export const RecentCard = ({
       onItemInView={onItemInView}
       onOpen={onOpen}
       onOpenOriginalUrl={onOpenOriginalUrl}
-      ActionMenu={ActionsRecent}
     />
   ) : null
 }

--- a/src/containers/home/home-similar-recs.js
+++ b/src/containers/home/home-similar-recs.js
@@ -1,3 +1,5 @@
+// Removed from Home on 5/19/22
+
 import { useEffect } from 'react'
 import { HomeSimilarHeader } from 'components/headers/home-header'
 import { useDispatch, useSelector } from 'react-redux'

--- a/src/containers/home/home.js
+++ b/src/containers/home/home.js
@@ -3,7 +3,6 @@ import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { HomeGreeting } from 'containers/home/home-greeting'
 import { HomeRecentSaves } from 'containers/home/home-recent-saves'
-import { HomeSimilarRecs } from 'containers/home/home-similar-recs'
 
 import { getHomeLineup } from 'containers/home/home.state'
 
@@ -67,7 +66,6 @@ export const Home = ({ metaData }) => {
         <Slate key={slateId} slateId={slateId} pagePosition={index} offset={offset} />
       ))}
 
-      <HomeSimilarRecs />
       <DeleteModal />
       <TaggingModal />
       <ShareModal />


### PR DESCRIPTION
## Goal

Requested to remove the Show Similar button on Recently Saved items on Home

## To Do:

- [x] Hide button

## Implementation Decisions

I left the components for now as this doesn't 100% feel like the right choice to me. I know I know, it's not up to me. But it feels _wrong_. Like, why are we removing it just because it's not getting a ton of engagement (and that is up in the air given we don't even have engagement events on that button). Can we put it on more cards, like in My List? Discover?? Feels weird, man.

Keeping as a draft as I get more questions answered.