### PR TITLE
fix(similar): add snowplow engagement event to show similar button [FRONT-1725]

### DIFF
--- a/src/connectors/item-card/home/card-recent-actions.js
+++ b/src/connectors/item-card/home/card-recent-actions.js
@@ -3,8 +3,9 @@ import { itemActionStyle } from 'components/item-actions/base'
 import { useSelector, useDispatch } from 'react-redux'
 import { getSimilarRecs } from 'containers/home/home.state'
 import { ShowSimilar } from 'components/item-actions/show-similar'
+import { sendSnowplowEvent } from 'connectors/snowplow/snowplow.state'
 
-export function ActionsRecent({ id }) {
+export function ActionsRecent({ id, position }) {
   const dispatch = useDispatch()
 
   const item = useSelector((state) => state.myListItemsById[id])
@@ -13,6 +14,8 @@ export function ActionsRecent({ id }) {
 
   // Similar action
   const onSimilar = () => {
+    const data = { id, position, ...item?.analyticsData }
+    dispatch(sendSnowplowEvent('home.similar.show', data))
     dispatch(getSimilarRecs(id))
   }
 

--- a/src/connectors/snowplow/actions/home.js
+++ b/src/connectors/snowplow/actions/home.js
@@ -68,6 +68,14 @@ export const homeActions = {
     },
     expects: ['id', 'url', 'position']
   },
+  'home.similar.show': {
+    eventType: 'engagement',
+    entityTypes: ['content', 'ui'],
+    eventData: {
+      uiType: 'button'
+    },
+    expects: ['id', 'url', 'position']
+  },
   'home.similar.impression': {
     eventType: 'impression',
     entityTypes: ['content', 'ui'],


### PR DESCRIPTION
## Goal

Instead of ditching this button outright, let's track actual engagement 

## To Do:

- [x] Add engagement event to show similar button

## Implementation Decisions

![watch](https://user-images.githubusercontent.com/1273879/170073872-8b2bcc5b-5d6b-472c-8ead-ec6862661fa1.gif)