### PR TITLE
fix(author by-line): use proper `Link` for author url

### DIFF
--- a/src/components/content-author/author-byline.js
+++ b/src/components/content-author/author-byline.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import Link from 'next/link'
 import { css } from 'linaria'
 
 const BylineWrapper = css`
@@ -79,7 +80,9 @@ function Authors({ authors }) {
 function AuthorByline({ url, name, showAuthors, authorNames }) {
   return (
     <cite className={BylineWrapper}>
-      <a href={url} data-cy="author-url">{name}</a>
+      <Link href={url}>
+        <a data-cy="author-url">{name}</a>
+      </Link>
       {showAuthors ? <Authors authors={authorNames} /> : null}
     </cite>
   )


### PR DESCRIPTION
## Goal

Author by-line was not wrapped in `Link` and so could not use localized routing properly.

## To Do:

- [x] Add `Link` to author by-line

![giphy-1](https://user-images.githubusercontent.com/16119672/171255888-4adf6f4e-524c-477d-a7e5-3413828bd9f7.gif)

