### PR TITLE
fix(syndicated article): adjusting consumption

### DIFF
--- a/src/common/api/queries/get-syndicated-article.js
+++ b/src/common/api/queries/get-syndicated-article.js
@@ -2,62 +2,30 @@ import { gql } from 'graphql-request'
 import { requestGQL } from 'common/utilities/request/request'
 
 const getSyndicatedArticleQuery = gql`
-  query GetSyndicatedArticle($slug: String) {
+  query GetSyndicatedArticle($slug: String!) {
     syndicatedArticleBySlug(slug: $slug) {
-      items {
-        id
-        legacyId
-        originalItemId
-        itemId
-        status
-        slug
-        showAds
-        publisherUrl
-        authorNames
-        expiresAt
-        contentId
-        localeLanguage
-        localeCountry
-        title
-        excerpt
-        publishedAt
-        publisherId
-        mainImage
-        iabTopCategory
-        iabSubCategory
-        curationCategory
-        content {
-          content
-        }
-        publisher {
-          id
-          legacyId
-          name
-          recommendationName
-          url
-          showAuthors
-          attributeCanonicalToPublisher
-          showArticleCta
-          appearedOnDomain
-          logo {
-            name
-            url
-          }
-          logoWide {
-            name
-            url
-          }
-          logoWideBlack {
-            name
-            url
-          }
-          articleCta {
-            url
-            text
-            leadIn
-          }
-        }
+      content
+      authorNames
+      curationCategory
+      excerpt
+      expiresAt
+      iabSubCategory
+      iabTopCategory
+      itemId
+      localeCountry
+      localeLanguage
+      mainImage
+      originalItemId
+      publishedAt
+      publisherUrl
+      publisher {
+        name
+        url
       }
+      showAds
+      slug
+      status
+      title
     }
   }
 `

--- a/src/containers/syndicated-article/syndicated-article.js
+++ b/src/containers/syndicated-article/syndicated-article.js
@@ -192,7 +192,7 @@ export function SyndicatedArticle({ queryParams = validParams, locale }) {
             <div className="content-body">
               {/* Parsed Content */}
               <ContentParsed
-                content={content?.content}
+                content={content}
                 trackScrollDepth={trackScrollDepth}
                 isMobileWebView={isMobileWebView}
               />

--- a/src/pages/discover/item/[slug].js
+++ b/src/pages/discover/item/[slug].js
@@ -23,18 +23,18 @@ export const getServerSideProps = wrapper.getServerSideProps(
       const response = await fetchHydrationData({ slug, baseUrl })
 
       // No article found
-      if (!response || response?.items?.length === 0) {
+      if (!response || !response?.content) {
         return { props: defaultProps, notFound: true }
       }
 
       if (response.items?.[0]?.status === 'EXPIRED') {
-        res.writeHead(301, { Location: response.items[0].publisherUrl })
+        res.writeHead(301, { Location: response.publisherUrl })
         res.end()
       }
 
       // Since ssr will not wait for side effects to resolve this dispatch
       // needs to be pure as well.
-      dispatch(hydrateArticle({ articleData: response?.items[0] }))
+      dispatch(hydrateArticle({ articleData: response }))
 
       // end the saga
       dispatch(END)


### PR DESCRIPTION
## Goal

Make some minor changes to adjust consumption of the new endpoint.

## To Do:

- [x] Set up query to use the schema
- [x] Adjust content consumers appropriately

## Implementation Decisions

Data comes down a bit different from the federated graph. This makes that adjustment and also adjusts the way it is consumed (not using first item)