### PR TITLE
fix(modal): fix modal overlay styles

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -195,14 +195,14 @@ const Modal = ({
           doesAnimateTransition && readyAnimate && !isOpen && 'animation-hide',
           forceMobile && 'force-mobile'
         )}
-        overlayClassName={cx([
+        overlayClassName={cx(
           overlayStyles,
           overlayClassName,
           doesAnimateTransition && 'animation-base',
           doesAnimateTransition && readyAnimate && isOpen && 'animation-show',
           doesAnimateTransition && readyAnimate && !isOpen && 'animation-hide'
-        ])}
-        portalClassName={cx([portalClassName])}
+        )}
+        portalClassName={cx(portalClassName)}
         closeTimeoutMS={closeTimeoutMS} // necessary to make outgoing animation display
         data-cy="modal"
         contentRef={(node) => (modalContentRef = node)}>


### PR DESCRIPTION
## Goal

There was a bug introduced when removing `classnames` in favor of `cx`

## To Do:

- [x] Fix it

## Implementation Decisions

`cx` doesn't want an array, and `classnames` did