### PR TITLE
fix(snowplow): fix race condition when parsing item id for content entity

### DIFF
--- a/src/connectors/snowplow/entities/content.js
+++ b/src/connectors/snowplow/entities/content.js
@@ -14,12 +14,16 @@ export const CONTENT_SCHEMA_URL = getSchemaUri('content')
  * @param id {int} - The backend identifier for a URL. @optional
  * @returns {{schema: *, data: {url: string, ?item_id: int}}}
  */
-const createContentEntity = ({ url, id }) => ({
-  schema: CONTENT_SCHEMA_URL,
-  data: getObjectWithValidKeysOnly({
-    url,
-    item_id: id ? parseInt(id, 10) : null
-  })
-})
+const createContentEntity = ({ url, id }) => {
+  const itemId = id ? parseInt(id, 10) : null
+
+  return {
+    schema: CONTENT_SCHEMA_URL,
+    data: getObjectWithValidKeysOnly({
+      url,
+      item_id: itemId
+    })
+  }
+}
 
 export default createContentEntity


### PR DESCRIPTION
## Goal

There were multiple instances of an `itemId` being sent to Snowplow with a `null` value. This shouldn't be possible as our `getObjectWithValidKeysOnly` function should automatically remove that value. Seems like there may be a race condition.

## To Do:

- [x] Parse the ItemID outside of `getObjectWithValidKeysOnly`

## Implementation Decisions

By running `parseInt` outside of `getObjectWithValidKeysOnly` it prevents the utility from evaluating that key as a function and therefore "truthy"