### PR TITLE
fix(topic-selection): make the topic selectors keyboard selectable and navigable

### DIFF
--- a/src/containers/get-started/select-topics.js
+++ b/src/containers/get-started/select-topics.js
@@ -38,12 +38,21 @@ const topicStyle = css`
   border: var(--borderStyle);
   border-radius: 8px;
   user-select: none;
-  span {
+  input {
     margin-right: 1rem;
     width: 18px;
     height: 18px;
     border: var(--borderStyle);
     border-radius: var(--borderRadius);
+    &:before {
+      content: url('data:image/svg+xml;charset=US-ASCII,<svg fill="%23008078" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M21.707 5.293a1 1 0 0 1 0 1.414l-12 12a1 1 0 0 1-1.414 0l-6-6a1 1 0 1 1 1.414-1.414L9 16.586 20.293 5.293a1 1 0 0 1 1.414 0Z"></path></svg>');
+      margin-top: -3px;
+    }
+    &:checked,
+    &:checked:hover {
+      border: var(--borderStyle);
+      background-color: var(--color-canvas);
+    }
   }
   &:hover,
   &.selected {
@@ -122,9 +131,9 @@ const TopicButton = ({ topic }) => {
   const toggleTopic = () => dispatch(topicAction(topic.name))
 
   return (
-    <div className={cx(topicStyle, isSelected && 'selected')} onClick={toggleTopic}>
-      <span>{isSelected ? <CheckIcon className="checkIcon" /> : null}</span>
+    <label className={cx(topicStyle, isSelected && 'selected')} >
+      <input type="checkbox" checked={isSelected} onChange={toggleTopic}/>
       {topic.name}
-    </div>
+    </label>
   )
 }


### PR DESCRIPTION
## Goal

Needed to make topic selection keyboard navigable and selectable for accessibility needs

## To Do:

- [x] Bumping up accessibility for keyboard warriors 💪 
- [x] Make sure to keep using the same checkbox to make Design happy 🎉 

## Implementation Decisions

By updating the `div` wrapper to a `label` that automatically makes the whole element targettable through tab index. Needing to move the `onClick` handler from the outer wrapper to the `onChange` event on the checkbox. We now get an extra focus border on the checkbox, but that's pretty standard across our website.

![2022-06-10 11 20 10](https://user-images.githubusercontent.com/1273879/173127219-c5a1a123-04ea-4f9c-bdd5-a8e0c964db75.gif)