### PR TITLE
fix(global nav): make logo hide/show work in all cases - FRONT-1783

### DIFF
--- a/src/components/global-nav/global-nav.js
+++ b/src/components/global-nav/global-nav.js
@@ -73,12 +73,14 @@ const headerStyle = css`
     .pocket-logo {
       margin-right: 1rem;
     }
-    .logo:not(.noNav) {
+
+    &.logged-in .logo {
       display: none;
     }
+
     &.logged-in {
-      .logo {
-        display: none;
+      .noNav.logo {
+        display: block;
       }
     }
 


### PR DESCRIPTION
## Goal

[Jira](https://getpocket.atlassian.net/browse/FRONT-1783)

Fix the logo disappearing on the setup moment pages on small screens. Also makes sure that the logo shows up or hides correctly in all the other cases.

**SETUP MOMENT** 
Logo should always be the Pocket logo icon w/ "Pocket" text. It should not be clickable. Mobile menu should never appear.
![logo-setup-moment](https://user-images.githubusercontent.com/2893463/173659681-ee0ebc31-e02b-4220-b4a5-fa11b41959e0.gif)

____

**LOGGED IN, OUTSIDE SETUP MOMENT**
Logo should be the Pocket logo icon w/ "Pocket" text on desktop and it should be clickable. Mobile menu should appear on smaller screens and the "Pocket" text should disappear and be replaced by the Pocket logo only.
![logo-logged-in-not-setup-moment](https://user-images.githubusercontent.com/2893463/173659808-1583b2e3-61a9-4aec-b341-cce89931e43b.gif)

____

**LOGGED OUT**
Logo should be the Pocket logo icon w/ "Pocket" text on desktop and it should be clickable. Mobile menu should appear on smaller screens, but the "Pocket" text should remain visible and not be replaced by the logo only.
![logo-logged-out](https://user-images.githubusercontent.com/2893463/173660808-9ce33d59-93e9-4d1d-8eb3-64ca3c019788.gif)

