### PR TITLE
fix(get-started): go to home on archive or delete actions in reader [FRONT-1793]

### DIFF
--- a/src/containers/read/read.state.js
+++ b/src/containers/read/read.state.js
@@ -469,12 +469,12 @@ function* checkMutations({ nodes }) {
 }
 
 function redirectToList() {
-  // setup moment
-  const getStarted = new URLSearchParams(window.location.search)?.has('getStarted')
-  if (getStarted) return document.location.href = '/home'
-
-  // default behavior
   if (document.location.href.indexOf('/read/') !== -1) {
+    // setup moment
+    const getStarted = new URLSearchParams(window.location.search)?.has('getStarted')
+    if (getStarted) return document.location.href = '/home'
+
+    // default behavior
     if (global.history.length > 1) {
       global.history.go(-1)
     } else {


### PR DESCRIPTION
## Goal

When archiving or deleting an item from Reader (after getting there from get started) return to Home

## To Do:

- [x] Navigate to Home when archiving or deleting from Reader (when the getStarted query param exists)

## Implementation Decisions

Checking for the `getStarted` query param on Reader, if it exists, head to Home