### PR TITLE
fix(get-started): fix duplicate impressions on select articles

### DIFF
--- a/src/containers/get-started/select-article.js
+++ b/src/containers/get-started/select-article.js
@@ -160,7 +160,7 @@ export const SelectArticleCard = ({
   const dispatch = useDispatch()
 
   const item = useSelector((state) => state.getStarted.articlesById[id])
-  const impressionFired = useSelector((state) => state.analytics.impressions.includes(id))
+  const impressionFired = useSelector((state) => state.analytics.impressions.includes(item?.url))
   if (!item) return null
 
   const { title, publisher, excerpt, timeToRead, isSyndicated, fromPartner, thumbnail, analyticsData } = item //prettier-ignore


### PR DESCRIPTION
## Goal

Impressions were firing twice due to being stored as URLs instead of IDs

## To Do:

- [x] Check impression by URL instead of ID

## Implementation Decisions

Lemons