### PR TITLE
fix(get-started): fix save confirm modal to prevent scroll lock

### DIFF
--- a/src/containers/get-started/save-confirm.js
+++ b/src/containers/get-started/save-confirm.js
@@ -64,7 +64,7 @@ export const SaveConfirm = () => {
   const showModal = !!savedArticleId
 
   const goToReader = () => router.push(`/read/${savedArticleId}?getStarted=true`)
-  return savedArticleId ? <SaveConfirmModal showModal={showModal} goToReader={goToReader} /> : null
+  return <SaveConfirmModal showModal={showModal} goToReader={goToReader} />
 }
 
 export const SaveConfirmModal = ({ showModal, goToReader }) => {


### PR DESCRIPTION
## Goal

When navigating back to the `select-article` page it would have a scroll lock on due to a class being added on the body. Fixing it...

## To Do:

- [x] Render modal but make use of the `showModal` prop

## Implementation Decisions

By relying on the `showModal` prop it removes the body class name that causes scroll lock