### PR TITLE
fix(home): add snowplow events for topic rec cards

### DIFF
--- a/src/connectors/item-card/home/card-topic-rec-actions.js
+++ b/src/connectors/item-card/home/card-topic-rec-actions.js
@@ -17,7 +17,7 @@ export function ActionsTopicRec({ id, position }) {
 
   // Prep save action
   const onSave = () => {
-    dispatch(sendSnowplowEvent('home.lineup.save', analyticsData))
+    dispatch(sendSnowplowEvent('home.topic-rec.save', analyticsData))
     dispatch(saveHomeItem(id, saveUrl, position))
   }
 
@@ -25,7 +25,7 @@ export function ActionsTopicRec({ id, position }) {
   const url = readUrl && !openExternal ? readUrl : externalUrl
   const onOpen = () => {
     const destination = saveStatus === 'saved' && !openExternal ? 'internal' : 'external'
-    dispatch(sendSnowplowEvent('home.lineup.open', { destination, ...analyticsData }))
+    dispatch(sendSnowplowEvent('home.topic-rec.open', { destination, ...analyticsData }))
   }
 
   return item ? (

--- a/src/connectors/item-card/home/card-topic-rec.js
+++ b/src/connectors/item-card/home/card-topic-rec.js
@@ -34,10 +34,10 @@ export const CardTopicRec = ({
    */
   const onOpenOriginalUrl = () => {
     const openData = { ...data, destination: 'external' }
-    dispatch(sendSnowplowEvent('home.lineup.view-original', openData))
+    dispatch(sendSnowplowEvent('home.topic-rec.view-original', openData))
   }
-  const onOpen = () => dispatch(sendSnowplowEvent('home.lineup.open', data))
-  const onImpression = () => dispatch(sendSnowplowEvent('home.lineup.impression', data))
+  const onOpen = () => dispatch(sendSnowplowEvent('home.topic-rec.open', data))
+  const onImpression = () => dispatch(sendSnowplowEvent('home.topic-rec.impression', data))
   const onItemInView = (inView) => (!impressionFired && inView ? onImpression() : null)
 
   /** ITEM DETAILS

--- a/src/connectors/snowplow/actions/home.js
+++ b/src/connectors/snowplow/actions/home.js
@@ -259,6 +259,56 @@ export const homeActions = {
       'description'
     ]
   },
+  'home.topic-rec.open': {
+    eventType: 'contentOpen',
+    entityTypes: ['content', 'ui'],
+    eventData: {
+      uiType: 'card'
+    },
+    expects: [
+      'id',
+      'url',
+      'position'
+    ]
+  },
+  'home.topic-rec.view-original': {
+    eventType: 'contentOpen',
+    entityTypes: ['content', 'ui'],
+    eventData: {
+      uiType: 'card'
+    },
+    expects: [
+      'id',
+      'url',
+      'position'
+    ]
+  },
+  'home.topic-rec.impression': {
+    eventType: 'impression',
+    entityTypes: ['content', 'ui'],
+    eventData: {
+      component: 'ui',
+      uiType: 'card'
+    },
+    expects: [
+      'id',
+      'url',
+      'position'
+    ]
+  },
+  'home.topic-rec.save': {
+    eventType: 'engagement',
+    entityTypes: ['content', 'ui'],
+    eventData: {
+      engagementType: 'save',
+      uiType: 'button'
+    },
+    expects: [
+      'id',
+      'url',
+      'position'
+    ]
+  },
   'home.bestof.impression': {
     eventType: 'impression',
     entityTypes: ['ui'],

--- a/src/containers/home/home.js
+++ b/src/containers/home/home.js
@@ -36,6 +36,7 @@ export const Home = ({ metaData }) => {
   const featureState = useSelector((state) => state.features) || {}
   const generalSlates = useSelector((state) => state.home.generalSlates)
   const topicSlates = useSelector((state) => state.home.topicSlates)
+  const recsByTopic = useSelector((state) => state.home.recsByTopic) || []
 
   const fallback = '249850f0-61c0-46f9-a16a-f0553c222800'
 
@@ -43,6 +44,7 @@ export const Home = ({ metaData }) => {
   const lineupId = lineupFlag?.payload?.slateLineupId || fallback
 
   const inGetStartedTest = featureFlagActive({ flag: 'getstarted', featureState })
+  const renderLineup = inGetStartedTest ? recsByTopic.length : true
 
   useEffect(() => {
     if (userStatus !== 'valid' || !lineupFlag) return
@@ -65,13 +67,13 @@ export const Home = ({ metaData }) => {
 
       {inGetStartedTest ? <HomeRecsByTopic /> : null}
 
-      {generalSlates?.map((slateId, index) => (
+      {renderLineup ? generalSlates?.map((slateId, index) => (
         <Slate key={slateId} slateId={slateId} pagePosition={index} offset={0} />
-      ))}
+      )) : null}
 
-      {topicSlates?.map((slateId, index) => (
+      {renderLineup ? topicSlates?.map((slateId, index) => (
         <Slate key={slateId} slateId={slateId} pagePosition={index} offset={offset} />
-      ))}
+      )) : null}
 
       <DeleteModal />
       <TaggingModal />


### PR DESCRIPTION
## Goal

Adding custom snowplow events for the topic rec cards (it was previously using the Home lineup events)

## To Do:

- [x] New analytics events
- [x] Hold rendering lineup until topic recs are available

## Implementation Decisions

Implemented with the help of @collectedmind and @wtfluckey 