### PR TITLE
fix(waypoint): direct non english users to my list

### DIFF
--- a/src/pages/waypoint.js
+++ b/src/pages/waypoint.js
@@ -25,7 +25,7 @@ export async function getServerSideProps({ req, locale, query, defaultLocale, lo
     const homeLink = queryString.stringifyUrl({ url: '/home', query })
     const getStartedLink = queryString.stringifyUrl({ url: '/get-started', query })
 
-    if (isSignUp && nonEnglish) {
+    if (isSignUp && !nonEnglish) {
       return {
         redirect: {
           permanent: false,


### PR DESCRIPTION
## Goal

Non English users were being directed to `get-started` on signup.

## To Do:

- [x] Add a `nonEnglish` constant
- [x] Use new constant to bypass `get-started`
- [x] Use new constant to continue to `my-list`

## Implementation Decisions

It will probably be a bit before we set up the `get-started` flow for non English users, so we should just keep them out of that flow for now