### PR TITLE
fix(card): make text overflow really work, add overflow-wrap to break words when needed - FRONT-1771

### DIFF
--- a/src/components/item-card/card-base.js
+++ b/src/components/item-card/card-base.js
@@ -88,8 +88,13 @@ export const cardStyles = css`
     max-height: 3.858em;
     overflow: hidden;
     text-overflow: ellipsis;
+    overflow-wrap: anywhere;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
     &.flow {
       max-height: initial;
+      display: block;
     }
   }
 


### PR DESCRIPTION
## Goal

Fix the text-overflow issue in the recommendations for [this item](https://www.mentalfloss.com/article/52136/11-simple-ways-improve-your-memory).

Bonus: Make the `text-overflow: ellipsis` actually work. The ellipses weren't showing up in the overflow cases, which makes it hard to know that the title is actually longer and getting truncated. By adding the line clamp property, it makes it so we can truncate at a specific number of lines and it makes the ellipses show up when it does truncate. 

[Jira](https://getpocket.atlassian.net/browse/FRONT-1771)

## To Do:

- [x] Add `overflow-wrap: anywhere;` so that words without a natural break will break
- [x] Add `-webkit-line-clamp` so the `text-overflow: ellipsis;` actually works
  - [More details on line clamp](https://css-tricks.com/almanac/properties/l/line-clamp/)
- [x] Don't include the line clamp when `.flow` class is added to `.title` because we want to show the full title in this case without any truncating
- [x] Test across the site to make sure titles are looking okay with these changes


**BEFORE**
<img width="871" alt="Screen Shot 2022-06-27 at 5 07 01 PM" src="https://user-images.githubusercontent.com/2893463/176035715-50ff2e78-7584-49b5-9de7-0387c2d996f5.png">

---

**AFTER**
<img width="786" alt="Screen Shot 2022-06-27 at 5 07 46 PM" src="https://user-images.githubusercontent.com/2893463/176035777-c7f35fd1-dc70-471e-b88a-a0115373a3f4.png">



