### PR TITLE
fix(modal): add a mobile specific max height smaller than 100vh [FRONT-1769]

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -23,7 +23,7 @@ const modalMobileStyles = `
   bottom: 0;
   top: auto;
   border-radius: 0;
-  max-height: 100vh;
+  max-height: calc(100vh - var(--spacing650));
   max-width: 100%;
   transform-origin: bottom;
 


### PR DESCRIPTION
## Goal

On mobile browsers when any extra tall modal is open, the top header and close button was hidden. Let's make it available to interact with!

## To Do:

- [x] Make max height on tall modals just a little smaller

## Implementation Decisions

Mobile Safari has this fun quirk where `100vh` includes the space that sits behind the address bar. I'm assuming this is due to the address bar appearing and disappearing from its position at the bottom of the screen. The issue comes to a head when we affix the modal to the bottom of the screen, which Safari places above the address bar. So now the modal is taller than the visible real estate.

I followed similar patterns elsewhere in the modal styles and am calculating the max height of the modal as `100vh` minus `6.5rem`, this will add spacing for the address bar, plus a smidge extra so you can still see some of the nav behind it.

<img width="395" alt="image" src="https://user-images.githubusercontent.com/1273879/176224919-b939431d-df83-4109-b7be-ade563d22c01.png">
