### PR TITLE
fix(select-articles): fix button text on dark mode

### DIFF
--- a/src/containers/get-started/select-article.js
+++ b/src/containers/get-started/select-article.js
@@ -123,9 +123,6 @@ const selectorCardStyle = css`
   .card-actions {
     margin-bottom: 0.25rem;
     padding: 0.75rem;
-    &:hover {
-      color: var(--color-textPrimary);
-    }
 
     &.border {
       border: var(--borderStyle);
@@ -133,7 +130,7 @@ const selectorCardStyle = css`
       border-color: var(--color-actionSecondary);
 
       .actionCopy {
-        color: var(--color-textPrimary);
+        color: var(--color-actionSecondaryText);
       }
 
       &:hover,


### PR DESCRIPTION
## Goal

The Save to My List button text was not readable in dark mode. Now it is. 🧙‍♀️ 

![dark-mode-button](https://user-images.githubusercontent.com/2893463/176287926-aafcdc3b-2bab-4d11-861c-e68ee135cdb3.gif)

