### PR TITLE
fix(pocket-graph): combine feature flags for graph

### DIFF
--- a/src/containers/read/read.js
+++ b/src/containers/read/read.js
@@ -17,7 +17,7 @@ export default function Read() {
   const deleted = useSelector((state) => state.reader.deleted)
   const flagsReady = useSelector((state) => state.features.flagsReady)
   const featureState = useSelector((state) => state.features)
-  const useClientAPI = flagsReady && featureFlagActive({ flag: 'reader.client-api', featureState })
+  const useClientAPI = flagsReady && featureFlagActive({ flag: 'api.next', featureState })
   const ContentToRender = useClientAPI ? Reader : LegacyReader
 
   useEffect(() => {
@@ -27,7 +27,7 @@ export default function Read() {
       router.replace(path)
       dispatch(clearDeletion())
     }
-  }, [deleted, router])
+  }, [deleted, router, dispatch])
 
   return <ContentToRender />
 }


### PR DESCRIPTION
## Goal
Unify flag we are using for the pocket-graph transition work (list/reader)

## To Do:

- [x] use `api.next` flag instead of `reader.client-api`

## Implementation Decisions

These flags were split so they could be tested independently.  After passing that muster, we want to combine them prior to socializing the test and asking people to join it.

![giphy-1](https://user-images.githubusercontent.com/16119672/179583516-043ed8d2-5791-457a-90fd-07311da50e3f.gif)
