### PR TITLE
fix(account): pick up rss privacy properly

### DIFF
--- a/src/containers/account/privacy/privacy.state.js
+++ b/src/containers/account/privacy/privacy.state.js
@@ -49,8 +49,9 @@ export const accountClearCancel = () => ({ type: ACCOUNT_CLEAR_CANCEL })
 export const userPrivacyReducers = (state = initialState, action) => {
   switch (action.type) {
     case USER_SUCCESS: {
-      const { profile } = action
-      return { ...state, rssProtected: profile.feed_protected || true }
+      const { user } = action
+      const rssProtected = user?.feed_protected === '1'
+      return { ...state, rssProtected }
     }
 
     case ACCOUNT_CLEAR_REQUEST: {


### PR DESCRIPTION
## Goal

This completes the puzzle of RSS feed privacy.  Updated the endpoint yesterday so the setting gets set properly.  This sets up our indicator so it properly displays the stored setting

## To Do:

- [x] Coerce string value into boolean
- [x] Pick up the stored value properly 

## Implementation Decisions

![giphy-3](https://user-images.githubusercontent.com/16119672/180039472-03e21efd-d2c3-4d94-ad20-a5c63eccbfde.gif)

