### PR TITLE
fix(account): email truncation on account page [FRONT-1756]

### DIFF
--- a/src/components/account/account.js
+++ b/src/components/account/account.js
@@ -20,7 +20,7 @@ export const accountStyles = css`
 
     &[id]:before {
       display: block;
-      content: "";
+      content: '';
       margin-top: -6rem;
       height: 6rem;
       visibility: hidden;
@@ -90,6 +90,13 @@ export const accountStyles = css`
     display: flex;
     align-items: center;
     align-content: center;
+  }
+  .emailDisplay {
+    display: block;
+    width: 100%;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
   .subButton {
     grid-column: span 2;

--- a/src/components/account/email/addresses.js
+++ b/src/components/account/email/addresses.js
@@ -32,7 +32,7 @@ const Alias = ({ onRemoveAlias, onResendConfirmation, alias, confirmed }) => {
   return (
     <>
       <div className="contentDisplay">
-        {alias}{' '}
+        <span className="emailDisplay">{alias}</span>
         {unconfirmed ? (
           <ErrorIcon
             className={`unconfirmed ${topTooltip}`}
@@ -75,7 +75,7 @@ export const EmailAddresses = ({
       <div className="sectionBody emailBody">
         <label htmlFor="primaryEmail">{t('account:email-primary', 'Primary Email')}</label>
         <div className="contentDisplay">
-          {primaryEmail}{' '}
+          <span className="emailDisplay">{primaryEmail}</span>
           {primaryUnConfirmed ? (
             <ErrorIcon
               className={`unconfirmed ${topTooltip}`}

--- a/src/components/account/email/addresses.story.js
+++ b/src/components/account/email/addresses.story.js
@@ -1,0 +1,30 @@
+import { css, cx } from 'linaria'
+import { EmailAddresses as EmailAddressesComponent } from './addresses'
+import { accountStyles } from '../account'
+
+export default {
+  title: 'Components/EmailAddresses'
+}
+
+const noop = () => {}
+export const EmailAddresses = () => {
+  const aliases = {
+    'thisistheevenlongestemail@wowwhyisthisolongImeanreallythisiscrazy.com': {},
+    'thelongestemailisevenlongerthattheotheremails@wowwhyisthisolongImeanreallythisiscrazy.com': {}
+  }
+  return (
+    <div className={accountStyles}>
+      <EmailAddressesComponent
+        primaryEmail="thisisthelongestemail@wowwhyisthisolongImeanreallythisiscrazy.com"
+        onChangeEmail={noop}
+        onAddEmailAlias={noop}
+        onChangeEmailAlias={noop}
+        emailAlias={''}
+        emailAliasError={''}
+        onResendConfirmation={noop}
+        onRemoveAlias={noop}
+        aliases={aliases}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Goal

Account page needs a full audit, but this solves an issue with long email addresses breaking a bit of the layout.

## To Do:

- [x] Add email text-overflow to the account page.

## Implementation Decisions

There will be a larger effort to audit this page in future, so this is an imperfect solution ... but a solution none the less.

![Screen Shot 2022-07-25 at 10 19 09 AM](https://user-images.githubusercontent.com/16119672/180837748-13f8ff22-a197-4e38-95a8-f3b9ddd4489a.png)

