### PR TITLE
fix(reader): use reader-settings for state [FRONT-1865]

### DIFF
--- a/src/containers/read/legacy-reader.js
+++ b/src/containers/read/legacy-reader.js
@@ -66,10 +66,10 @@ export default function LegacyReader() {
   const tags = useSelector((state) => state.reader.tags)
   const favorite = useSelector((state) => state.reader.favorite)
 
-  const lineHeight = useSelector((state) => state.reader.lineHeight)
-  const columnWidth = useSelector((state) => state.reader.columnWidth)
-  const fontSize = useSelector((state) => state.reader.fontSize)
-  const fontFamily = useSelector((state) => state.reader.fontFamily)
+  const lineHeight = useSelector((state) => state.readerSettings.lineHeight)
+  const columnWidth = useSelector((state) => state.readerSettings.columnWidth)
+  const fontSize = useSelector((state) => state.readerSettings.fontSize)
+  const fontFamily = useSelector((state) => state.readerSettings.fontFamily)
   const colorMode = useSelector((state) => state?.app?.colorMode)
 
   const [sideBarOpen, setSideBar] = useState(false)


### PR DESCRIPTION
## Goal

Reader settings was not being updated in the legacy state.

## To Do:

- [x] User `reader-settings` state for settings

## Implementation Decisions

This is where we are heading and works independently of graph/v3
