### PR TITLE
fix(highlights): do not save empty highlight string [FRONT-1171]

### DIFF
--- a/src/connectors/reader/highlights.js
+++ b/src/connectors/reader/highlights.js
@@ -56,6 +56,7 @@ export const Highlights = ({ children, id }) => {
   }
 
   const addAnnotation = () => {
+    if (!highlight.toString()) return
     if (annotations.length === 3 && !isPremium) return setAnnotationLimitModal(true)
 
     dispatch(sendSnowplowEvent('reader.add-highlight', analyticsData))

--- a/src/connectors/reader/sidebar.js
+++ b/src/connectors/reader/sidebar.js
@@ -2,7 +2,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { Sidebar } from 'components/reader/sidebar'
 import { cx } from 'linaria'
 import { toggleSidebar } from 'containers/read/reader.state'
-import { deleteHighlightRequest } from 'containers/read/read.state'
+import { mutationHighlightDelete } from 'connectors/items/mutation-highlight.state'
 import { shareAction } from 'connectors/share-modal/share-modal.state'
 import { sendSnowplowEvent } from 'connectors/snowplow/snowplow.state'
 
@@ -32,7 +32,7 @@ export const SidebarWrapper = ({ id }) => {
 
   const removeAnnotation = (annotationId) => {
     dispatch(sendSnowplowEvent('reader.remove-highlight', analyticsData))
-    dispatch(deleteHighlightRequest({ annotationId }))
+    dispatch(mutationHighlightDelete({ annotationId, savedItemId: id }))
   }
 
   return (

--- a/src/containers/read/legacy-reader.js
+++ b/src/containers/read/legacy-reader.js
@@ -167,18 +167,17 @@ export default function LegacyReader() {
   const analyticsInfo = { ...analyticsData, id: itemId }
 
   const addAnnotation = () => {
-    if (annotations.length === 3 && !isPremium) {
-      setAnnotationLimitModal(true)
-    } else {
-      dispatch(sendSnowplowEvent('reader.add-highlight', analyticsInfo))
-      dispatch(
-        saveAnnotation({
-          itemId,
-          patch: requestAnnotationPatch(highlight),
-          quote: highlight.toString()
-        })
-      )
-    }
+    if (!highlight.toString()) return
+    if (annotations.length === 3 && !isPremium) return setAnnotationLimitModal(true)
+
+    dispatch(sendSnowplowEvent('reader.add-highlight', analyticsInfo))
+    dispatch(
+      saveAnnotation({
+        itemId,
+        patch: requestAnnotationPatch(highlight),
+        quote: highlight.toString()
+      })
+    )
   }
 
   const removeAnnotation = (annotation_id) => {


### PR DESCRIPTION
## Goal

Do not save empty highlight strings

## To Do:

- [x] Fix it for `pocket-graph` implementation
- [x] Fix it for `v3` implementation
- [x] BONUS: fix delete highlight in sidebar for `pocket-graph`

## Implementation Decisions

![nothing there](https://user-images.githubusercontent.com/1273879/181609778-f6a62429-c53b-4c3b-bf10-22655acf1a88.gif)