### PR TITLE
fix(share): adding quote to sharing on twitter [FRONT-1456]

### DIFF
--- a/src/components/share-modal/share-list.js
+++ b/src/components/share-modal/share-list.js
@@ -58,7 +58,7 @@ export const ShareList = ({ openUrl, excerpt, title, quote, engagementEvent, can
         network="twitter"
         label={t('share:share-to-twitter', 'Share to Twitter')}
         onSocialShare={onSocialShare}
-        text={title}
+        text={quote || title}
         url={openUrl}
       />
 

--- a/src/components/social-button/social-button.js
+++ b/src/components/social-button/social-button.js
@@ -52,7 +52,7 @@ const SocialNetworks = {
   twitter: {
     width: 550,
     height: 400,
-    params: ['url', 'text', 'via'], // text === title
+    params: ['url', 'text', 'via'], // text === quote || title
     shareUrl: 'https://twitter.com/share',
     icon: TwitterColorIcon
   },

--- a/src/connectors/confirm-share/share-social.js
+++ b/src/connectors/confirm-share/share-social.js
@@ -68,7 +68,7 @@ export const ShareSocial = ({ openUrl, excerpt, title, itemId, quote, position =
         network="twitter"
         label={t('share:share-to-twitter', 'Share to Twitter')}
         onSocialShare={onSocialShare}
-        text={title}
+        text={quote || title}
         url={openUrl}
       />
 


### PR DESCRIPTION
## Goal

Add quote to sharing on Twitter

## To Do:

- [x] Update sharing on both v3 and pocket-graph

## Implementation Decisions

Easy `quote || title`
 
![sharing](https://user-images.githubusercontent.com/1273879/182217327-f8b46d9a-4b96-4132-9267-e16aaa5fb38b.gif)
