### PR TITLE
fix(recent saves): adjust original view styling treatment for recent saves cards

### DIFF
--- a/src/components/item-card/card-base.js
+++ b/src/components/item-card/card-base.js
@@ -1,4 +1,5 @@
 import { css } from 'linaria'
+import { breakpointSmallDesktop } from 'common/constants'
 import { breakpointLargeTablet } from 'common/constants'
 import { breakpointMediumTablet } from 'common/constants'
 import { breakpointSmallTablet } from 'common/constants'
@@ -698,9 +699,19 @@ export const cardStyles = css`
       }
     }
 
+    ${breakpointSmallDesktop} {
+      .original-view-text {
+        display: none;
+      }
+    }
+
     ${breakpointMediumTablet} {
       --media-column-span: span 12;
       --content-column-span: span 12;
+
+      .original-view-text {
+        display: inline;
+      }
     }
 
     ${breakpointSmallTablet} {
@@ -716,6 +727,10 @@ export const cardStyles = css`
     &:only-of-type {
       --media-column-span: span 3;
       --content-column-span: span 9;
+
+      .original-view-text {
+        display: inline;
+      }
 
       ${breakpointMediumTablet} {
         --media-column-span: span 4;
@@ -733,9 +748,17 @@ export const cardStyles = css`
     // https://css-tricks.com/solved-with-css-logical-styling-based-on-the-number-of-given-elements/
     &:first-child:nth-last-child(n + 3),
     &:first-child:nth-last-child(n + 3) ~ * {
+      .original-view-text {
+        display: none;
+      }
+
       ${breakpointLargeTablet} {
         --media-column-span: span 12;
         --content-column-span: span 12;
+
+        .original-view-text {
+          display: inline;
+        }
       }
 
       ${breakpointMediumTablet} {


### PR DESCRIPTION
## Goal

Make it so the `Original View` styling treatment doesn't wrap to a new line when the card image isn't wide enough.

**One Item:**
![recent-saves-original-view-1](https://user-images.githubusercontent.com/2893463/185220828-9978d0bc-0613-45cb-8236-fcf535e5488c.gif)

**Two Items:**
![recent-saves-original-view-2](https://user-images.githubusercontent.com/2893463/185220904-40356814-d111-4e28-83c8-7f04a84230c2.gif)

**Three items:**
![recent-saves-original-view-3](https://user-images.githubusercontent.com/2893463/185220941-7ae9ed00-ccea-44b2-a7b2-a1be9c02dc38.gif)

