### PR TITLE
fix(snowplow): update impression event for publisher cta [FRONT-1897]

### DIFF
--- a/src/components/content-publisher/publisher-attribution.js
+++ b/src/components/content-publisher/publisher-attribution.js
@@ -59,13 +59,16 @@ const AttributionWrapper = css`
 `
 
 function FollowPublisher({ leadIn, text, url, handleImpression, handleClick }) {
+  const onVisible = () => handleImpression(text)
+  const onClick = () => handleClick(text)
+
   return (
-    <VisibilitySensor onVisible={handleImpression}>
+    <VisibilitySensor onVisible={onVisible}>
       <div className="publisher-follow" data-cy="follow-publisher">
         <p>{leadIn}</p>
         <Button
           variant="secondary"
-          onClick={handleClick}
+          onClick={onClick}
           href={url}
           /* eslint-disable-next-line */
           target="_blank">
@@ -98,14 +101,6 @@ function PublisherAttribution({
   handlePublisherImpression,
   handlePublisherClick
 }) {
-  function handleImpression() {
-    handlePublisherImpression(publisher.name)
-  }
-
-  function handleClick() {
-    handlePublisherClick(publisher.name)
-  }
-
   return publisher ? (
     <cite className={AttributionWrapper}>
       <PublisherInfo
@@ -116,8 +111,8 @@ function PublisherAttribution({
       {publisher.articleCta ? (
         <FollowPublisher
           {...publisher.articleCta}
-          handleImpression={handleImpression}
-          handleClick={handleClick}
+          handleImpression={handlePublisherImpression}
+          handleClick={handlePublisherClick}
         />
       ) : null}
     </cite>

--- a/src/connectors/snowplow/actions/syndicated-article.js
+++ b/src/connectors/snowplow/actions/syndicated-article.js
@@ -74,7 +74,8 @@ export const syndicatedArticleActions = {
     eventType: 'impression',
     entityTypes: ['ui'],
     eventData: {
-      uiType: 'button'
+      uiType: 'button',
+      component: 'button',
     },
     expects: ['label'],
     description:

--- a/src/connectors/snowplow/events/impression.js
+++ b/src/connectors/snowplow/events/impression.js
@@ -4,12 +4,14 @@ import { getSchemaUri } from 'connectors/snowplow/snowplow.utilities'
  * Schema information:
  * https://console.snowplowanalytics.com/cf0fba6b-23b3-49a0-9d79-7ce18b8f9618/data-structures/ee6a84772fc144d0e5b58ca5f461ebdccfbab784067c823e4a7a60744dc5235f
  */
-const IMPRESSION_SCHEMA_URL = getSchemaUri('impression')
+const IMPRESSION_SCHEMA_URL = getSchemaUri('impression', '1-0-2')
 
 export const IMPRESSION_COMPONENT_UI = 'ui'
 export const IMPRESSION_COMPONENT_CARD = 'card'
 export const IMPRESSION_COMPONENT_CONTENT = 'content'
 export const IMPRESSION_COMPONENT_SCREEN = 'screen'
+export const IMPRESSION_COMPONENT_PUSH_NOTIFICATION = 'push_notification'
+export const IMPRESSION_COMPONENT_BUTTON = 'button'
 
 export const IMPRESSION_REQUIREMENT_INSTANT = 'instant'
 export const IMPRESSION_REQUIREMENT_VIEWABLE = 'viewable'
@@ -21,7 +23,9 @@ export const IMPRESSION_REQUIREMENT_VIEWABLE = 'viewable'
         IMPRESSION_COMPONENT_UI,
         IMPRESSION_COMPONENT_CARD,
         IMPRESSION_COMPONENT_CONTENT,
-        IMPRESSION_COMPONENT_SCREEN
+        IMPRESSION_COMPONENT_SCREEN,
+        IMPRESSION_COMPONENG_PUSH_NOTIFICATION,
+        IMPRESSION_COMPONENT_BUTTON
         )} - Indicator of the component that is being viewed @required
  * @param requirement {(
         IMPRESSION_REQUIREMENT_INSTANT,


### PR DESCRIPTION
## Goal

Add component type button to publisher impression

## To Do:

- [x] Pass in correct label text
- [x] Update impression snowplow schema
- [x] Pass in correct component type

## Implementation Decisions

![vibin](https://user-images.githubusercontent.com/1273879/187255518-5ac3ab66-719f-4536-8f9c-066ec6fe5e0e.gif)