### PR TITLE
fix(sort order): fix error post list request overhaul

### DIFF
--- a/src/containers/list-saved/list-saved.state.js
+++ b/src/containers/list-saved/list-saved.state.js
@@ -123,6 +123,7 @@ export const listSavedReducers = (state = [], action) => {
 const initialState = {
   sortOrder: 'DESC',
   count: 30,
+  loading: true,
   totalCount: 0,
   tagNames: [],
   error: false
@@ -132,9 +133,7 @@ export const listSavedPageInfoReducers = (state = initialState, action) => {
     case ITEMS_SAVED_TAGGED_REQUEST:
     case ITEMS_SAVED_SEARCH_REQUEST:
     case ITEMS_SAVED_REQUEST: {
-      const { filters, actionType } = action
-      const { sortOrder } = filters?.sort || {}
-
+      const { sortOrder = 'DESC', actionType } = action
       return { ...state, error: false, loading: true, sortOrder, actionType }
     }
 


### PR DESCRIPTION
## Goal

When the operationNames got added, sort order was a bit borked. This fixes that.

## To Do:

- [x] Fix the borked sort order state

## Implementation Decisions

Bork bork bork bork.

![giphy](https://user-images.githubusercontent.com/16119672/187307297-83a39e09-83c3-48bc-b3cb-f419c89735cd.gif)
