### PR TITLE
fix(listen): cleanup border so it looks good across both firefox and chrome

### DIFF
--- a/src/components/audio/audio.js
+++ b/src/components/audio/audio.js
@@ -17,7 +17,8 @@ const audioStyles = css`
   audio {
     display: inline-block;
     width: 100%;
-    border-radius: 4px;
+    height: 42px;
+    border-radius: 22px;
     border: 1px solid var(--color-textSecondary);
   }
 


### PR DESCRIPTION
## Goal

Update the border styles so it looks good on Firefox and Chrome

## To Do:

- [x] Update border radius
- [x] Add an explicit height

## Implementation Decisions

Adding an `outline: none` didn't actually work, as adding it to the inspector would cause the border declaration to break, which is what made it work. So I worked with Oli and he agreed that updating the border radius would be the best way to go about it.