### PR TITLE
fix(PopupMenuItem): wrap <a> in <Link> to retain lang prefix

### DIFF
--- a/src/components/global-nav/account/global-nav-account.spec.js
+++ b/src/components/global-nav/account/global-nav-account.spec.js
@@ -35,7 +35,7 @@ describe('GlobalNavAccount', () => {
       <GlobalNavAccount {...baseProps} isLoggedIn profileUrl="getpocket.com/123kitties" />
     )
     const profileLink = getByCy('account-menu-profile-link')
-    expect(profileLink).toHaveAttribute('href', 'getpocket.com/123kitties')
+    expect(profileLink).toHaveAttribute('href', '/getpocket.com/123kitties')
   })
 
   it('renders the "view profile" menu link using props.accountName as the display name', () => {

--- a/src/components/popup-menu/popup-menu.js
+++ b/src/components/popup-menu/popup-menu.js
@@ -5,7 +5,7 @@ import Popup from 'components/popup/popup'
 import Modal from 'components/modal/modal'
 import { useViewport } from 'components/viewport-provider/viewport-provider'
 import { screenLargeHandset, breakpointLargeHandset } from 'common/constants'
-import Link from 'node_modules/next/link'
+import Link from 'next/link'
 
 const popupStyle = css`
   // make sure this style has precedence over built in popup styles


### PR DESCRIPTION
## Goal
Navigating to the Account Settings page was dropping the lang prefix in the url, resulting in a non-translated page.

## To Do:

- [x] Wrap `<a>` in `<Link>`
- [x] Fix the tests

