### PR TITLE
fix(waypoint): add error handling for no cookie and no user

### DIFF
--- a/src/pages/waypoint.js
+++ b/src/pages/waypoint.js
@@ -9,7 +9,7 @@ export default function Waypoint() {}
 export async function getServerSideProps({ req, locale, query, defaultLocale, locales }) {
   try {
     // returns first two letters of browser defined language settings
-    const lang = req.headers['accept-language'].toString().substring(0, 2)
+    const lang = req.headers['accept-language']?.toString().substring(0, 2)
     const supportedLocale = locales.includes(lang)
     const langPrefix = lang !== defaultLocale && supportedLocale ? `/${lang}` : ''
     // const isSignUp = query['type'] === 'signup'


### PR DESCRIPTION
## Goal

Need to add additional error logging on waypoint to detect cookie and/or user errors

## To Do:

- [x] Add error for no cookie
- [x] Add error for no user
- [x] BONUS: Add a conditional for the `accept-language` headers so an error isn't thrown if not needed

## Implementation Decisions

Are there additional places we need an error? 

![fork](https://user-images.githubusercontent.com/1273879/189194520-32362aef-2027-480a-9a99-ec3cd53e8b54.gif)
