### PR TITLE
fix(home): removing topic mix until endpoints are sorted

### DIFF
--- a/src/containers/home/home.js
+++ b/src/containers/home/home.js
@@ -76,7 +76,7 @@ export const Home = ({ metaData }) => {
 
   // We can no longer wait on topic mix since there is a possibility userTopics will exist
   // but we are no ready to render
-  const shouldRenderTopicMix = storedTopicsReady && userTopics.length && !isPersonalized
+  const shouldRenderTopicMix = false // storedTopicsReady && userTopics.length && !isPersonalized
 
   useEffect(() => {
     if (userStatus !== 'valid' || !lineupFlag) return


### PR DESCRIPTION
## Goal

Hotfix for topic mix. 

## To Do:

- [x] set should render topic mix to false

## Implementation Decisions

Endpoints are down and we are entering a long weekend.