### PR TITLE
DRAFT - fix(card): move actions menu out of footer - FRONT-1801

### DIFF
--- a/src/components/item-card/card.js
+++ b/src/components/item-card/card.js
@@ -254,12 +254,10 @@ export const Card = (props) => {
               )}
             </div>
           ) : null}
+          {ActionMenu ? <ActionMenu id={actionId || itemId} position={position} /> : null}
         </div>
       </div>
-      <footer className="footer">
-        {showTags ? <ItemTags tags={tags} /> : null}
-        {ActionMenu ? <ActionMenu id={actionId || itemId} position={position} /> : null}
-      </footer>
+      <footer className="footer">{showTags ? <ItemTags tags={tags} /> : null}</footer>
     </article>
   )
 }


### PR DESCRIPTION
## Goal

Move the save button closer to the rest of the content
[Jira](https://getpocket.atlassian.net/browse/FRONT-1801)

## To Do:

- [ ] **Bulk edit icon alignment**
<img width="300" alt="Screen Shot 2022-09-20 at 3 43 43 PM" src="https://user-images.githubusercontent.com/2893463/191350175-eb9428a1-c865-4bdf-b2fe-61f2c5ce0dd4.png">

--- 

- [ ] **Reduce padding?**
<img width="300" alt="Screen Shot 2022-09-20 at 3 45 07 PM" src="https://user-images.githubusercontent.com/2893463/191350392-9173ab54-8017-428b-a570-aee747781b35.png">

--- 

- [ ] **Permanent copy icon color on hover (HOW?)**
<img width="213" alt="Screen Shot 2022-09-20 at 3 50 11 PM" src="https://user-images.githubusercontent.com/2893463/191351263-6fe0871b-fb55-4106-9030-bf742d6163fe.png">

--- 

- [ ] **spacing gets a little wonky when there's no excerpt on detail card shape**
<img width="400" alt="Screen Shot 2022-09-20 at 3 56 44 PM" src="https://user-images.githubusercontent.com/2893463/191352491-f6c04ca8-49a1-4018-934d-95d96f745a2b.png">

--- 

- [ ] **Detail: Tags flow below the item actions**
<img width="400" alt="Screen Shot 2022-09-20 at 3 58 22 PM" src="https://user-images.githubusercontent.com/2893463/191352927-8df9e4ed-5e10-4265-81e7-518cbfc31f2f.png">

--- 

- [ ] **List: Alignment is off**
<img width="960" alt="Screen Shot 2022-09-20 at 4 13 47 PM" src="https://user-images.githubusercontent.com/2893463/191355634-bda4f546-3543-4ba8-8598-e40c2d92f796.png">
