### PR TITLE
DRAFT - fix(card): adjust styling so the save button is closer to the content - FRONT-1801

### DIFF
--- a/src/components/item-actions/base.js
+++ b/src/components/item-actions/base.js
@@ -2,7 +2,7 @@ import { css } from 'linaria'
 
 export const itemActionStyle = css`
   display: flex;
-  padding: var(--size100) 0 var(--size025);
+  padding: var(--size025) 0;
   justify-content: space-between;
   .item-actions {
     display: flex;

--- a/src/components/item-card/card-base.js
+++ b/src/components/item-card/card-base.js
@@ -29,8 +29,6 @@ export const cardStyles = css`
   grid-row: var(--card-row-span);
 
   .cardWrap {
-    position: relative;
-    height: 100%;
     width: 100%;
     text-decoration: none;
     display: grid;
@@ -224,8 +222,6 @@ export const cardStyles = css`
 
   .footer {
     width: 100%;
-    position: absolute;
-    bottom: 0;
     display: grid;
     grid-template-columns: repeat(12, 1fr);
   }
@@ -274,7 +270,6 @@ export const cardStyles = css`
 
     .cardWrap {
       display: block;
-      padding-bottom: 2.5rem;
     }
 
     /* Hide actions on block cards only */
@@ -318,7 +313,6 @@ export const cardStyles = css`
 
       .cardWrap {
         display: grid;
-        padding-bottom: 1.85rem;
       }
 
       .footer .actions {
@@ -336,10 +330,6 @@ export const cardStyles = css`
   &.wide,
   &.display {
     --card-column-span: span 8;
-
-    .content {
-      padding-bottom: var(--size250);
-    }
 
     .title {
       font-size: var(--fontSize150);


### PR DESCRIPTION
## Goal

Move the save button closer to the rest of the content
[Jira](https://getpocket.atlassian.net/browse/FRONT-1801)

## To Do:

- [ ] **Detail shape needs a lot of love on most screen sizes**
<img width="400" alt="Screen Shot 2022-09-20 at 4 37 52 PM" src="https://user-images.githubusercontent.com/2893463/191361291-bf3ae9c7-3e77-4d21-8ad9-2c086b697bea.png">

---

- [ ] **Grid: Bulk edit icon alignment**
<img width="300" alt="Screen Shot 2022-09-20 at 4 55 43 PM" src="https://user-images.githubusercontent.com/2893463/191362789-25e02f8a-c5d1-4f4c-b038-d1b4a8d275b6.png">
