### PR TITLE
fix(document): add ios meta tag to document instead of head file

### DIFF
--- a/src/containers/_layouts/_head.js
+++ b/src/containers/_layouts/_head.js
@@ -65,7 +65,6 @@ export const PocketHead = ({ metaData = {}, title: pageTitle, canonical, forceWe
       <meta name="apple-mobile-web-app-title" content="Pocket" />
       <meta name="apple-mobile-web-app-capable" content="yes" />
       <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-      <meta name="apple-itunes-app" content="app-id=309601447" />
 
       {/* Windows */}
       <meta name="msapplication-TileColor" content="#ef4056" />

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -8,6 +8,9 @@ class ClientDocument extends Document {
       <Html>
         {/* prettier-ignore */}
         <Head>
+          {/* Loads an iOS app store banner at the top of Safari */}
+          <meta name="apple-itunes-app" content="app-id=309601447" />
+
           {/*
           This all sets us up for color themes without having a flash of
           light if the user has chosen another color mode as the default
@@ -34,10 +37,10 @@ class ClientDocument extends Document {
           />
 
           {/* <!-- OneTrust Cookies Consent Notice start for getpocket.com --> */}
-          <script 
-            src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  
-            type="text/javascript" 
-            charSet="UTF-8" 
+          <script
+            src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
+            type="text/javascript"
+            charSet="UTF-8"
             data-domain-script="a7ff9c31-9f59-421f-9a8e-49b11a3eb24e"></script>
           {/* <!-- OneTrust Cookies Consent Notice end for getpocket.com --> */}
 
@@ -65,7 +68,7 @@ class ClientDocument extends Document {
               var gptadslots = [];
               var googletag = googletag || {cmd:[]};
             `
-            }} 
+            }}
           />
 
         <script async src='https://fdyn.pubwise.io/script/8bfeb37f-2e7b-4828-a1ef-65bed8f5f77c/v3/dyn/pre_pws.js'/>


### PR DESCRIPTION
## Goal

Looks like the meta tag didn't work on client-side-rendered pages, so I moved it to `_document`

## To Do:

- [x] Remove from `_head`
- [x] Add to `_document`

## Implementation Decisions

![thumbs up](https://user-images.githubusercontent.com/1273879/191847902-c95c1db4-574b-4ddc-a92a-88f53a78c3f4.gif)
