### PR TITLE
fix(home): make card next responsive

### DIFF
--- a/src/components/item-card/card-next.js
+++ b/src/components/item-card/card-next.js
@@ -204,6 +204,10 @@ export const cardNextStyles = css`
   --cite-column-span: span 8;
   --actions-column-span: span 4;
 
+  ${breakpointSmallTablet} {
+    --card-column-span: span 12;
+  }
+
   width: 100%;
   height: 100%;
   padding: 0;


### PR DESCRIPTION
## Goal

VERY basic responsive adjustment for card-next.  This is all behind a temp flag so gonna safe hot-fix this.

## To Do:

- [x] Add basic grid adjustment to small tablets

