### PR TITLE
fix(list-settings): update list settings from grid display to flex [FRONT-1972]

### DIFF
--- a/src/components/display-settings/list-modes.js
+++ b/src/components/display-settings/list-modes.js
@@ -11,8 +11,9 @@ import { bottomTooltip } from 'components/tooltip/tooltip'
 import { useTranslation } from 'next-i18next'
 
 const listSettingStyle = css`
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  display: flex;
+  justify-content: space-evenly;
+
   div {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Goal

The account menu displayed as full width in latest version of Safari. Fixing so it's collapsed to default width

## To Do:

- [x] Update display on List Settings

## Implementation Decisions

Discovered that the latest version of Safari handles `display: grid` in a different way than other browsers so that it automatically treats it as a `width: 100%`, which is what was causing the width to blow up.

Updating to a flex layout fixes the issue, and it still looks good everywhere else.

### Old and busted
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/1273879/195410625-21d9b098-c057-4f3d-a261-64602eee329e.png">


### New hotness
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/1273879/195410705-50c2bf66-d8ec-4dff-9885-5b411101f5db.png">
