### PR TITLE
fix(home): fix impression event to include component type [FRONT-1982]

### DIFF
--- a/src/connectors/snowplow/actions/home.js
+++ b/src/connectors/snowplow/actions/home.js
@@ -342,6 +342,7 @@ export const homeActions = {
     eventType: 'impression',
     entityTypes: ['content', 'ui', 'corpusRecommendation'],
     eventData: {
+      component: 'ui',
       uiType: 'card'
     },
     expects: ['corpusRecommendationId', 'url']


### PR DESCRIPTION
## Goal

Analytics had an increase in impression failures.

## To Do:

- [x] Fix impression failures by adding component

## Implementation Decisions

This was just something we missed in the review process. Luckily it was an easy fix

![fix](https://user-images.githubusercontent.com/1273879/195661114-c9c66730-b165-489c-9088-c27fd27f7f37.gif)
