### PR TITLE
fix(next): adding rewrite rule to prevent downtime during the switch

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,7 +28,8 @@ const nextOptions = {
       { source: '/explore/item/:slug', destination: '/discover/item/:slug' },
       { source: '/explore/:slug', destination: '/discover/:slug' },
       { source: '/web-client-health', destination: '/health' },
-      { source: '/web-client-api/:path*', destination: '/api/:path*' }
+      { source: '/web-client-api/:path*', destination: '/api/:path*' },
+      { source: '/my-list', destination: '/saves' },
     ]
   },
   async redirects() {


### PR DESCRIPTION
## Goal

Since we no longer use terraforms, we need to add a rewrite rule to the next config to prevent any downtime when making the switch from My List to Saves

## To Do:

- [x] Add rewrite rule for saves

## Implementation Decisions

I went with a rewrite vs a redirect for simplicity. When adding redirects, I'd need to include a rule for _each_ url under `my-list`: archive, favs, filters, search, tags, tags with wildcards, tags with wildcards and filters, etc. It would have gotten unwieldy _super_ quickly.

As this is something that would really only be in effect for 10ish mins while waiting for the change from the `dotcom-gateway` to go into effect, a rewrite seemed simpler.

What this means in the end is that users will see "Saves" as the header and in the global nav, but the url will still say `my-list`.

Where there is a possible complication is when people click on the "Saves" link in the global nav. The user will be directed to `getpocket.com/saves`, and it will load just fine due to the single page application nature. However if a user refreshes the page or navigates to `getpocket.com/saves` in a new tab or something, it'll load our 404 page. 

If y'all think I should just suck it up and write all those redirects, then I'll do so. If y'all think that couple of mins won't make too much difference, then 