### PR TITLE
fix(home): increase pocket hits count

### DIFF
--- a/src/containers/home/home-content.js
+++ b/src/containers/home/home-content.js
@@ -46,14 +46,15 @@ function Slate({ slateId, position }) {
 
   const { headline, subheadline, moreLink, recommendations, recommendationReasonType } = slate
 
-  const recCount = slates.indexOf(slateId) === 0 ? 6 : 3
-  const recsToShow = recommendations.slice(0, recCount)
-
-  const forceHits = featureFlagActive({ flag: 'pocket-hits.force', featureState })
   const showSlide = featureFlagActive({ flag: 'pocket-hits.slide', featureState })
 
   const showTopicSelector = recommendationReasonType === 'PREFERRED_TOPICS'
-  const showHits = recommendationReasonType === 'POCKET_HITS' || (forceHits && position === 0)
+  const showHits = recommendationReasonType === 'POCKET_HITS'
+
+  const recCount = slates.indexOf(slateId) === 0 || showHits ? 6 : 3
+  const recsToShow = recommendations.slice(0, recCount)
+
+
 
   const slateLink = showTopicSelector ? { text: 'Update topics', url: false } : moreLink
 


### PR DESCRIPTION
## Goal

We were limiting count based on first position slates.  This also accounts for slates with the `POCKET_HITS` reason.  

## To Do:

- [x] Change count logic

![giphy](https://user-images.githubusercontent.com/16119672/197880539-16bc0750-d80c-41ee-9b68-feb0f7bba298.gif)
