### PR TITLE
fix(build): updating buildspec to install npm version less than 9 [FRONT-2035]

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -52,7 +52,7 @@ phases:
       - ln -s ~/.tfenv/bin/* /usr/bin
       - tfenv install
       - tfenv use $(cat .terraform-version)
-      - npm install -g npm
+      - npm install -g npm@"<9.0.0"
       - npm install
       - npm run build
       # synthesize the js into terraform json with the proper node environment


### PR DESCRIPTION
## Goal

PRs were failing on the AWS build step, due to latest version of `npm` being incompatible with node `14.5.0` (default npm in codebuild)

## To Do:

- [x] Install specific version of `npm`

## Implementation Decisions

Took a look at what others in Pocket [are doing](https://pocket.slack.com/archives/C03QVL4SU/p1668102397670279)

![less](https://user-images.githubusercontent.com/1273879/201734525-4b00344d-13d2-436b-9003-dcdd2e56aaa0.gif)
