### PR TITLE
fix(reader): simplify delete from reader check [FRONT-1851]

### DIFF
--- a/src/containers/read/read.js
+++ b/src/containers/read/read.js
@@ -1,8 +1,5 @@
-import { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
-import { useRouter } from 'next/router'
+import { useSelector } from 'react-redux'
 import { featureFlagActive } from 'connectors/feature-flags/feature-flags'
-import { clearDeletion } from './read.state'
 import LegacyReader from './legacy-reader'
 import Reader from './reader'
 
@@ -11,23 +8,10 @@ export const LINE_HEIGHT_RANGE = [1.2, 1.3, 1.4, 1.5, 1.65, 1.9, 2.5]
 export const FONT_RANGE = [16, 19, 22, 25, 28, 32, 37]
 
 export default function Read() {
-  const router = useRouter()
-  const dispatch = useDispatch()
-
-  const deleted = useSelector((state) => state.reader.deleted)
   const flagsReady = useSelector((state) => state.features.flagsReady)
   const featureState = useSelector((state) => state.features)
   const useClientAPI = flagsReady && featureFlagActive({ flag: 'api.next', featureState })
   const ContentToRender = useClientAPI ? Reader : LegacyReader
-
-  useEffect(() => {
-    if (deleted) {
-      const { getStarted } = router.query
-      const path = getStarted ? '/home' : '/saves'
-      router.replace(path)
-      dispatch(clearDeletion())
-    }
-  }, [deleted, router, dispatch])
 
   return flagsReady ? <ContentToRender /> : null
 }

--- a/src/containers/read/read.state.js
+++ b/src/containers/read/read.state.js
@@ -132,10 +132,6 @@ export const readReducers = (state = initialState, action) => {
       return { ...state, deleted: !!deleted }
     }
 
-    case MUTATION_DELETE_SUCCESS: {
-      return { ...state, deleted: true }
-    }
-
     case READER_CLEAR_DELETION: {
       return { ...state, deleted: false }
     }

--- a/src/containers/read/reader.js
+++ b/src/containers/read/reader.js
@@ -83,6 +83,16 @@ export default function Reader() {
   const { slug: id } = router.query
 
   const item = useSelector((state) => state.items[id])
+  const status = useSelector((state) => state.itemsSaved[id]?.status)
+
+  // Is deleted ?
+  useEffect(() => {
+    if (status === 'DELETED') {
+      const { getStarted } = router.query
+      const path = getStarted ? '/home' : '/saves'
+      router.replace(path)
+    }
+  }, [status, router, dispatch])
 
   // Display settings
   const lineHeight = useSelector((state) => state.readerSettings.lineHeight)


### PR DESCRIPTION
## Goal

Setting specific reader state to determine if an item was deleted created some convolution and inconsistency with `reader` links.  This removes the custom tracking in favor of saved item state

## To Do:

- [x] Remove custom delete tracking
- [x] Get status from `saveItems`
- [x] Check status for `DELETED` and redirect in that instance
