### PR TITLE
fix(undelete): restore itemSaved status after undo

### DIFF
--- a/src/connectors/items/items-saved.state.js
+++ b/src/connectors/items/items-saved.state.js
@@ -9,6 +9,7 @@ import { ITEMS_SAVED_REQUEST } from 'actions'
 import { ITEMS_SAVED_SUCCESS } from 'actions'
 import { ITEMS_SAVED_FAILURE } from 'actions'
 import { ITEMS_UPSERT_SUCCESS } from 'actions'
+import { ITEMS_UNDELETE_SUCCESS } from 'actions'
 
 import { ITEMS_SAVED_SEARCH_REQUEST } from 'actions'
 import { ITEMS_SAVED_SEARCH_FAILURE } from 'actions'
@@ -35,6 +36,11 @@ export const itemsSavedReducers = (state = {}, action) => {
     case ITEMS_UPSERT_SUCCESS:
     case READ_ITEM_SUCCESS: {
       return { ...state, ...action.nodes }
+    }
+
+    case ITEMS_UNDELETE_SUCCESS: {
+      const { itemId, previousStatus } = action
+      return { ...state, [itemId]: { ...state[itemId], status: previousStatus } }
     }
 
     case MUTATION_DELETE_SUCCESS: {

--- a/src/connectors/toasts/toast.js
+++ b/src/connectors/toasts/toast.js
@@ -169,7 +169,15 @@ const errors = [
   PROFILE_ITEM_DELETE_FAILURE
 ]
 
-export function Toast({ stamp, type, ids, actionType, deletedItemPosition, itemCount = 1 }) {
+export function Toast({
+  stamp,
+  type,
+  ids,
+  actionType,
+  deletedItemPosition,
+  itemCount = 1,
+  previousStatus
+}) {
   const dispatch = useDispatch()
   const { t } = useTranslation()
 
@@ -195,7 +203,7 @@ export function Toast({ stamp, type, ids, actionType, deletedItemPosition, itemC
   }, [])
 
   const handleUndo = () => {
-    dispatch(mutationUnDelete(ids, deletedItemPosition))
+    dispatch(mutationUnDelete(ids, deletedItemPosition, previousStatus))
     remove()
   }
 

--- a/src/connectors/toasts/toast.state.js
+++ b/src/connectors/toasts/toast.state.js
@@ -61,10 +61,13 @@ export const actionToastsReducers = (state = initialState, action) => {
     }
 
     case MUTATION_DELETE_SUCCESS: {
-      const { ids, deletedItemPosition } = action
+      const { ids, deletedItemPosition, previousStatus } = action
       const itemCount = ids.length
       const stamp = Date.now()
-      return [...state, { stamp, type: action.type, ids, itemCount, deletedItemPosition }]
+      return [
+        ...state,
+        { stamp, type: action.type, ids, itemCount, deletedItemPosition, previousStatus }
+      ]
     }
 
     case ITEMS_DELETE_SUCCESS:


### PR DESCRIPTION
## Goal

If status isn't updated, heading to reader after delete causes problems

## To Do:

- [x] Store previous status
- [x] Restore previous status on un-delete
