### PR TITLE
fix(reader): add commas between multiple authors [FRONT-2042]

### DIFF
--- a/src/components/reader/header.js
+++ b/src/components/reader/header.js
@@ -112,11 +112,14 @@ const tagsWrapper = css`
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 function listAuthors(authors) {
   if (!authors) return
-  return Object.keys(authors).map((authorKey) => {
+  const authorKeys = Object.keys(authors)
+  return authorKeys.map((authorKey, index) => {
+    const isLast = index === authorKeys.length - 1
     const current = authors[authorKey]
     return (
       <span className={authorNoLink} key={authorKey}>
-        {current.name}{' '}
+        {current.name}
+        {isLast ? null : ','}{' '}
       </span>
     )
   })


### PR DESCRIPTION
## Goal
Add commas between multiple authors

## To Do:

- [x] Add commas after every author but the last (even if the first is the last)

## Implementation Decisions

Keeping it simple