### PR TITLE
fix(collections index): update metadata for Best Of campaign

### DIFF
--- a/src/containers/collections/collections.js
+++ b/src/containers/collections/collections.js
@@ -28,7 +28,7 @@ export default function Collections({ locale }) {
 
   // Remove Best Of specific metadata once the campaign is complete
   const bestOfImage =
-    'https://pocket-image-cache.com/648x/filters:format(png):extract_focal()/https%3A%2F%2Fs3.amazonaws.com%2Fpocket-collectionapi-prod-images%2Fe0f19ac2-0dd2-4af6-b6c2-d69afc32de8b.jpeg'
+    'https://s3.amazonaws.com/pocket-collectionapi-prod-images/20a5c150-c497-400a-a4be-a035225be3e8.jpeg'
 
   const metaData = {
     // description: t('collections:page-description', 'Curated guides to the best of the web'),


### PR DESCRIPTION
## Goal
Per the request in [this slack thread](https://pocket.slack.com/archives/C016PHP9PBK/p1669817377027659), we are updating the metadata on the collections index page to be specific to the 2022 Best Of campaign (to be removed once the campaign is complete)

## To Do:

- [x] Update title and description
- [x] Add custom image to metadata (using the image from the first 2022 Best Of collection)
- [x] Went ahead and sent off a job to smartling since this will be up for a month (https://github.com/Pocket/web-localization/pull/119)
- [ ] What am I missing?

![best-of-metadata](https://user-images.githubusercontent.com/2893463/204847207-0ff12b82-2c0d-4675-bbd8-cb48d24f2e12.gif)
