### PR TITLE
fix(tagging): fetch user tags from the graph [FRONT-2060]

### DIFF
--- a/src/connectors/confirm-tags/confirm-tag-mutation.js
+++ b/src/connectors/confirm-tags/confirm-tag-mutation.js
@@ -36,7 +36,7 @@ export function MutationTaggingModal() {
   const tagSuggestions = useSelector((state) => state.mutationTagging.tagSuggestions)
   const tagSuggestionStatus = useSelector((state) => state.mutationTagging.tagSuggestionStatus)
   const tagsSince = useSelector((state) => state.userTags.since)
-  const allTags = useSelector((state) => state.userTags.tagsList)
+  const allTags = useSelector((state) => state.userTags.tagNames)
 
   const showModal = itemsToTag?.length > 0
   const isSingleTag = itemsToTag.length === 1
@@ -107,7 +107,6 @@ export function MutationTaggingModal() {
   }, [itemsToTag, isPremium, dispatch])
 
   useEffect(() => {
-    if (tagsSince) return
     dispatch(requestUserTags())
   }, [dispatch, tagsSince])
 
@@ -154,7 +153,7 @@ export function MutationTaggingModal() {
             // Passed Props
             addTag={handleAdd}
           />
-          {allTags.length > 0 ? (
+          {allTags?.length > 0 ? (
             <TypeAhead
               reFocus={setFocus}
               setValue={addTag}

--- a/src/containers/saves/tags-page/tags-page.state.js
+++ b/src/containers/saves/tags-page/tags-page.state.js
@@ -67,6 +67,11 @@ export const userTagsReducers = (state = initialState, action) => {
       }
     }
 
+    case USER_TAGS_SUCCESS: {
+      const { tagNames } = action
+      return { ...state, tagNames }
+    }
+
     case USER_TAGS_EDIT: {
       const { tag } = action
       return { ...state, tagToEdit: tag }
@@ -134,9 +139,12 @@ const getPinnedTags = (state) => state.settings.pinnedTags
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 function* userTagsOnly() {
   // This will need to be part of the larger request organization
-  // For now we are keeping this as a placeholder to avoid double requesting
-  // during the apiNext testing.
-  // const response = yield getUserTagsGraph()
+  const response = yield getUserTagsGraph()
+
+  if (!response) yield put({ type: USER_TAGS_FAILURE })
+
+  const { tagNames } = response
+  yield put({ type: USER_TAGS_SUCCESS, tagNames })
 }
 
 function* userTagsRequest() {


### PR DESCRIPTION
## Goal

Fetch users tags for populating tag mutations dropdown

## To Do:

- [x] Fetch user tags from the graph
- [x] Use separate store for graph tags (until cleanup)

## Implementation Decisions

This will get it working for the 50% of users on the graph.  I want to optimize this when I do cleanup.

