### PR TITLE
fix(sort order): disable current order

### DIFF
--- a/src/components/list-sort/list-sort.js
+++ b/src/components/list-sort/list-sort.js
@@ -80,6 +80,10 @@ export const ListSort = ({
     relevance: <RelevanceIcon />
   }
 
+  const sortAscDisabled = sortOrder === 'ASC' || sortOrder === 'oldest'
+  const sortDescDisabled = sortOrder === 'DESC' || sortOrder === 'newest'
+  const relevanceDisabled = sortOrder === 'RELEVANCE' || sortOrder == 'relevance'
+
   return (
     <div ref={menuRef}>
       <button
@@ -106,16 +110,19 @@ export const ListSort = ({
             }
           ]
         }}>
-        <PopupMenuItem data-cy="sort-oldest" onClick={handleOldest}>
+        <PopupMenuItem data-cy="sort-oldest" onClick={handleOldest} disabled={sortAscDisabled}>
           <SortByOldestIcon />
           {t('settings:sort-oldest', 'Oldest first')}
         </PopupMenuItem>
-        <PopupMenuItem data-cy="sort-newest" onClick={handleNewest}>
+        <PopupMenuItem data-cy="sort-newest" onClick={handleNewest} disabled={sortDescDisabled}>
           <SortByNewestIcon />
           {t('settings:sort-newest', 'Newest first')}
         </PopupMenuItem>
         {showRelevance ? (
-          <PopupMenuItem data-cy="sort-relevance" onClick={handleRelevance}>
+          <PopupMenuItem
+            data-cy="sort-relevance"
+            onClick={handleRelevance}
+            disabled={relevanceDisabled}>
             <RelevanceIcon />
             {t('settings:sort-relevance', 'By relevance')}
           </PopupMenuItem>

--- a/src/containers/list-saved/list-saved.state.js
+++ b/src/containers/list-saved/list-saved.state.js
@@ -111,8 +111,13 @@ export const listSavedReducers = (state = [], action) => {
       return currentItems
     }
 
+    case ITEMS_SAVED_PAGE_SET_SORT_ORDER: {
+      const { sortOrder: passedSortOrder } = action
+      if (state.sortOrder !== passedSortOrder) return []
+      return state
+    }
+
     // ! This is agressive clearing of the list
-    case ITEMS_SAVED_PAGE_SET_SORT_ORDER:
     case ITEMS_SAVED_PAGE_SET_SORT_BY:
     case ITEMS_CLEAR_CURRENT: {
       return []


### PR DESCRIPTION
## Goal
Over aggressive clearing of list on sort order change could lead to an empty list if sorted by the current order.  This puts more checks and balances in place. 

## To Do:

- [x] Disable current sort order action
- [x] Check sort order for equality before clearing list-saved

## Implementation Decisions

This is almost identical to an old PR that got closed instead of merged.  The old one implied more functionality and this work was _sneaky_ ... sneaky no longer, this is the main intent.

![giphy](https://user-images.githubusercontent.com/16119672/205710783-2238adfd-c589-4652-8169-0f7192234ac8.gif)
