### PR TITLE
fix(analytics): re-adding resolvedURL for recs

### DIFF
--- a/src/common/api/derivers/item.js
+++ b/src/common/api/derivers/item.js
@@ -361,7 +361,7 @@ function saveUrl({ item, itemEnrichment }) {
  * @returns {string} The url that should be passed to analytics
  */
 function analyticsUrl({ node, item, itemEnrichment }) {
-  return node?.url || item?.givenUrl || itemEnrichment?.url || false
+  return node?.url || item?.givenUrl || item?.resolvedUrl || itemEnrichment?.url || false
 }
 
 /** READ URl


### PR DESCRIPTION
## Goal

Resolved url may still be required. This just re-adds it to the chain of data.  This will all get further sorted in the cleanup.  But better safe than sorry for now.

## To Do:

- [x] Re-Add resolvedUrl as a fallback analytic url
