### PR TITLE
fix(user): invalidate on bad sess_guid

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -61,7 +61,12 @@ function PocketWebClient({ Component, pageProps, err }) {
      */
     const initializeUser = async () => {
       const sess_guid = await getSessGuid()
-      if (!sess_guid) return
+      if (!sess_guid) {
+        // The reason we wouldn't get a sessGuid is because of a cors error (AKA on a non-pocket)
+        // so we want to invalidate the user at this point ex: https://getpocket.com/v3/guid
+        dispatch(setUser(true))
+        return
+      }
       dispatch(sessGuidHydrate(sess_guid))
       dispatch(setUser(false))
     }


### PR DESCRIPTION
## Goal

If we are trying to load the site in a dev environment, the user validation just silently fails.  This aims to make it fail with purpose.

## To Do:

- [x] Invalidate user if the sess guid is failing

## Implementation Decisions

Need some clarity here so we don't send logged in users into a loop-of-doom.  This may lead us to the path of better guid management where we can just roll our own ... but for now, this will unblock the dev deployment from not loading the ad services.