### PR TITLE
fix(waypoint): remove sess_guid check

### DIFF
--- a/src/pages/waypoint.js
+++ b/src/pages/waypoint.js
@@ -23,9 +23,6 @@ export async function getServerSideProps({ req, locale, query, defaultLocale, lo
     const savesLink = queryString.stringifyUrl({ url: `${langPrefix}/saves`, query })
     const homeLink = queryString.stringifyUrl({ url: '/home', query })
 
-    const { sess_guid } = req.cookies
-    if (!sess_guid) throw new WaypointNoSessGuidError()
-
     const response = await getUserInfo(true, req?.headers?.cookie)
     const { user_id, birth } = response?.user || {}
     if (!user_id) throw new WaypointNoUserIdError()
@@ -66,13 +63,6 @@ export async function getServerSideProps({ req, locale, query, defaultLocale, lo
         destination: '/saves'
       }
     }
-  }
-}
-
-class WaypointNoSessGuidError extends Error {
-  constructor(message) {
-    super(message)
-    this.name = 'WaypointNoSessGuidError'
   }
 }
 


### PR DESCRIPTION
## Goal

Cut down on sentry errors

## To Do:

- [x] Remove custom sess_guid error
- [x] Remove throw of error when there is no sess_guid

## Implementation Decisions

We do this check for sess_guid, that I believe was all about getting unleash assignments right ... but there is no more unleash assignments in waypoint.  Since this accounts for a ton of errors in our sentry, I think it is safe to drop this condition.  

_Bonus: the analytics team is all set up to no longer need this value anyway.  The future is coming_

![giphy](https://user-images.githubusercontent.com/16119672/205994100-436b846c-7ccb-49a7-87a6-14a0acc27fe5.gif)
