### PR TITLE
fix(collections): index the response ids

### DIFF
--- a/src/containers/collections/collections.js
+++ b/src/containers/collections/collections.js
@@ -8,18 +8,13 @@ import { CardPageHeader } from 'components/headers/discover-header'
 import { ItemCard } from 'connectors/item-card/collection/collection-card'
 import { Lockup } from 'components/items-layout/list-lockup'
 import { OffsetList } from 'components/items-layout/list-offset'
-
 import { Toasts } from 'connectors/toasts/toast-list'
 
-import { useTranslation } from 'next-i18next'
-
 export default function Collections({ locale }) {
-  const { t } = useTranslation()
 
   const isAuthenticated = useSelector((state) => state.user.auth)
   const userStatus = useSelector((state) => state.user.user_status)
-  const items = useSelector((state) => state.collectionsBySlug)
-  const itemIds = Object.keys(items)
+  const itemIds = useSelector((state) => state.collectionsPage)
   const shouldRender = userStatus !== 'pending'
 
   const languagePrefix = locale === 'en' ? '' : `/${locale}`

--- a/src/containers/collections/collections.state.js
+++ b/src/containers/collections/collections.state.js
@@ -33,9 +33,27 @@ export const unSaveCollectionPage = (slug) => ({ type: COLLECTION_PAGE_UNSAVE_RE
 
 /** REDUCERS
  --------------------------------------------------------------- */
-const initialState = {}
+export const collectionsPageReducers = (state = [], action) => {
+  switch (action.type) {
+    case COLLECTIONS_HYDRATE: {
+      const { payload } = action
+      return Object.keys(payload)
+    }
 
-export const collectionsReducers = (state = initialState, action) => {
+    // SPECIAL HYDRATE:  This is sent from the next-redux wrapper and
+    // it represents the state used to build the page on the server.
+    case HYDRATE: {
+      const { collectionsPage } = action.payload
+      return collectionsPage
+    }
+
+    default:
+      return state
+  }
+}
+
+
+export const collectionsBySlugReducers = (state = {}, action) => {
   switch (action.type) {
     case COLLECTIONS_HYDRATE: {
       const { payload } = action

--- a/src/store.js
+++ b/src/store.js
@@ -38,7 +38,8 @@ import { discoverItemsSagas } from 'connectors/items-by-id/discover/items.state'
 import { discoverHomeReducers } from 'containers/discover/discover.state'
 import { discoverHomeSagas } from 'containers/discover/discover.state'
 
-import { collectionsReducers } from 'containers/collections/collections.state'
+import { collectionsPageReducers } from 'containers/collections/collections.state'
+import { collectionsBySlugReducers } from 'containers/collections/collections.state'
 import { collectionsSagas } from 'containers/collections/collections.state'
 
 import { collectionStoriesReducers } from 'connectors/items-by-id/collection/stories.state'
@@ -179,7 +180,8 @@ const discoverReducers = {
 }
 
 const collectionReducer = {
-  collectionsBySlug: collectionsReducers,
+  collectionsPage: collectionsPageReducers,
+  collectionsBySlug: collectionsBySlugReducers,
   collectionStoriesById: collectionStoriesReducers
 }
 


### PR DESCRIPTION
## Goal

When a user went from collection pages and then back to the index page, the previously viewed collection would take the top spot on the index page.  This is because we were indexing the page based on the available slugs as opposed to when the initial response happened.

## To Do:

- [x] Add a `collectionsPage` state
- [x] Populate the `collectionsPage` state at response time
- [x] Use the `collectionsPage` state to build the collections page instead of the currently available slugs.

## Implementation Decisions

![giphy](https://user-images.githubusercontent.com/16119672/207460749-12370f92-a77e-4f9a-a7c7-ea7cccab88d1.gif)

My favorite Doctor