### PR TITLE
feat(build image): update buildspec to work w/new pocket-build image

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -45,7 +45,7 @@ phases:
       - npm install
       - npm run build
       # synthesize the js into terraform json with the proper node environment
-      - 'if [ "$GIT_BRANCH" == "$DEV_BRANCH" ]; then NODE_ENV=development npm run synth; else npm run synth; fi'
+      - 'if [ "$GIT_BRANCH" = "$DEV_BRANCH" ]; then NODE_ENV=development npm run synth; else npm run synth; fi'
       - cd cdktf.out/stacks/web-client
       - rm -rf .terraform # remove sym-link to ../.terraform (if this sym-link exists, terraform doesn't apply correctly. hmmmm)
       - terraform init
@@ -56,13 +56,13 @@ phases:
       ### If the branch is not main and its not dev, lets do a plan on prod.
       - 'if [ "$CODEBUILD_WEBHOOK_HEAD_REF" != "$MAIN_BRANCH_REF" ] && [ "$CODEBUILD_WEBHOOK_HEAD_REF" != "$DEV_BRANCH_REF" ]; then terraform plan -lock=false -refresh=false -no-color; fi'
       #### If the branch is dev, lets do an apply on dev.
-      - 'if [ "$GIT_BRANCH" == "$DEV_BRANCH" ]; then TF_WORKSPACE=$TF_DEV_WORKSPACE TF_LOG=INFO terraform apply -auto-approve -no-color; fi'
+      - 'if [ "$GIT_BRANCH" = "$DEV_BRANCH" ]; then TF_WORKSPACE=$TF_DEV_WORKSPACE TF_LOG=INFO terraform apply -auto-approve -no-color; fi'
       #### If the branch is main lets apply.
-      - 'if [ "$GIT_BRANCH" == "$MAIN_BRANCH" ]; then terraform apply -auto-approve -no-color; fi'
+      - 'if [ "$GIT_BRANCH" = "$MAIN_BRANCH" ]; then terraform apply -auto-approve -no-color; fi'
   post_build:
     run-as: circleci
     commands:
-      - 'if [ "$GIT_BRANCH" == "$MAIN_BRANCH" ] || [ "$GIT_BRANCH" == "$DEV_BRANCH" ]; then cp appspec.json taskdef.json ../../../../; fi'
+      - 'if [ "$GIT_BRANCH" = "$MAIN_BRANCH" ] || [ "$GIT_BRANCH" = "$DEV_BRANCH" ]; then cp appspec.json taskdef.json ../../../../; fi'
       # get back to the root dir
       - cd ../../
       - echo Build completed on `date`


### PR DESCRIPTION
## Goal

Follows successful review, merge & deploy of https://github.com/Pocket/shared-infrastructure/pull/506 & https://github.com/Pocket/shared-infrastructure/pull/507

Updates the repo's own Codebuild spec to work with the new pocket-build image, which doesn't require install steps (minus some uncertainty about perl-utils). Changes from alpine to ubuntu OS. This addresses multiple reports of Codebuild issues on the current (about to be replaced, unless you want to delay on changing) hashicorp/terraform image, which builds upon older versions of Alpine. If you want to opt out, just let me know here and I'll not change this repo's codebuild image in the upstream PRs.

Blocked by [#507](https://github.com/Pocket/shared-infrastructure/pull/507) (which updates the codebuild project to use the new image which this buildspec will run on).

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/INFRA-847
