### PR TITLE
fix(document): adding the google tags script back to main document file

### DIFF
--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -61,6 +61,14 @@ class ClientDocument extends Document {
           `
             }}
           />
+
+          <script dangerouslySetInnerHTML={{
+            __html: `
+              var gptadslots = [];
+              var googletag = googletag || {cmd:[]};
+            `
+            }}
+          />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
## Goal

Need this script back in place as freestar is not adding it

## To Do:

- [x] re-add gtag script

## Implementation Decisions

Implemented based on Joel's request