### PR TITLE
fix(tagging): disallow question marks in tags [FRONT-2096]

### DIFF
--- a/src/components/tagging/tag.input.js
+++ b/src/components/tagging/tag.input.js
@@ -55,7 +55,7 @@ export function TagInput(props) {
 
   /* Input Events
   –––––––––––––––––––––––––––––––––––––––––––––––––––– */
-  const onChange = (event) => setValue(event.target.value)
+  const onChange = (event) => setValue(event.target.value.replace(/[?]/g, ''))
   const onKeyUp = (event) => {
     switch (event.keyCode) {
       // Handle intent to remove

--- a/src/connectors/confirm-tags/confirm-tag-edit.js
+++ b/src/connectors/confirm-tags/confirm-tag-edit.js
@@ -23,7 +23,7 @@ export const TagEditModal = () => {
   const tagToEdit = useSelector((state) => state.userTags.tagToEdit)
 
   const [value, setValue] = useState('')
-  const onChange = (event) => setValue(event.target.value)
+  const onChange = (event) => setValue(event.target.value.replace(/[?]/g, ''))
 
   const showModal = tagToEdit !== false
   const confirmTagEdit = () => dispatch(confirmEditUserTag(tagToEdit, value, router)) // prettier-ignore


### PR DESCRIPTION
## Goal

Prevent question mark characters from being used in tags

## To Do:

- [x] Add regex to change handlers of tagging modal and tag mutate modal
