### PR TITLE
fix(tagging): adding question mark into a tag breaks URL [FRONT-2096]

### DIFF
--- a/src/containers/saves/tags-page/tags-page.state.js
+++ b/src/containers/saves/tags-page/tags-page.state.js
@@ -210,7 +210,7 @@ function* userTagsEditConfirm(action) {
     const pinnedItems = yield select(getPinnedTags)
     const pinnedTags = pinnedItems.map((pin) => (old_tag === pin ? new_tag : pin)) //prettier-ignore
     yield put({ type: USER_TAGS_EDIT_SUCCESS, new_tag, old_tag, pinnedTags }) //prettier-ignore
-    return yield call(router.replace, `/saves/tags/${encodeURI(new_tag)}`)
+    return yield call(router.replace, `/saves/tags/${encodeURIComponent(new_tag)}`)
   }
 
   return yield put({ type: USER_TAGS_EDIT_FAILURE, old_tag })


### PR DESCRIPTION
## Goal

Adding a question mark into a tag should not break the UI

## To Do:

- [x] In the case above, prevent question marks from being treated as query param markers