### PR TITLE
fix(toasts): fix {{count}} is appearing in some languages [FONT-1811]

### DIFF
--- a/src/connectors/toasts/toast.js
+++ b/src/connectors/toasts/toast.js
@@ -7,7 +7,7 @@ import { ErrorIcon } from 'components/icons/ErrorIcon'
 import { Fade } from 'common/utilities/animation/fade'
 import { useDispatch } from 'react-redux'
 import { clearToast } from './toast.state'
-import { Trans, useTranslation } from 'next-i18next'
+import { useTranslation } from 'next-i18next'
 import { mutationUnDelete } from 'connectors/items/mutation-delete.state'
 
 import { MUTATION_DELETE_SUCCESS } from 'actions'
@@ -211,9 +211,9 @@ export function Toast({
     <Fade show={show} remove={remove}>
       <div className={toastWrapper}>
         <div className={cx('toastBlock', `${type}`)} data-cy={messages[typeForMessage]}>
-          <div>
-            <Trans i18nKey={messages[typeForMessage]} count={itemCount} />
-          </div>
+          <p>
+            {t(messages[typeForMessage], {count: itemCount})}
+          </p>
           <div className="actionWrapper">
             {showUndo ? (
               <button onClick={handleUndo} className="text">


### PR DESCRIPTION
## Goal

Fix "{{count}}" is being displayed instead of actual number in some languages

<img width="336" alt="image" src="https://user-images.githubusercontent.com/14023085/214443336-1c0780b6-2254-46a0-9984-1d0a56980471.png">
<img width="428" alt="image" src="https://user-images.githubusercontent.com/14023085/214443634-99fc77ce-538d-45a3-b9a0-afbf7f006b68.png">

vs
<img width="325" alt="image" src="https://user-images.githubusercontent.com/14023085/214443530-e2fb348a-eb1f-4f52-bb62-468b9f878c8a.png">
<img width="435" alt="image" src="https://user-images.githubusercontent.com/14023085/214442896-73e9876c-e60f-47ea-bb08-9a4775a3a5ff.png">



## To Do:

- [x] Fix the thing

## Implementation Decisions

This was the monstrosity of an alternative I came up with before our discussion in Slack today

```
          <div>
            {itemCount === 0 || Boolean(itemCount) ? (
              <Trans i18nKey={messages[typeForMessage]} count={itemCount}>
                {{count: 'anything'}}
              </Trans>
            ): (
              <Trans i18nKey={messages[typeForMessage]} />
            )}
          </div>
```