### PR TITLE
fix(waypoint): allow home to use lang prefix

### DIFF
--- a/src/pages/waypoint.js
+++ b/src/pages/waypoint.js
@@ -24,7 +24,7 @@ export async function getServerSideProps({ req, locale, query, defaultLocale, lo
     unusedQueryParams.forEach((param) => delete query[param])
 
     const savesLink = queryString.stringifyUrl({ url: `${langPrefix}/saves`, query })
-    const homeLink = queryString.stringifyUrl({ url: '/home', query })
+    const homeLink = queryString.stringifyUrl({ url: `${langPrefix}/home`, query })
 
     const response = await getUserInfo(true, req?.headers?.cookie)
     const { user_id, birth } = response?.user || {}


### PR DESCRIPTION
## Goal

Home wasn't set up to use a lang prefix in the redirect link since it wasn't necessary before.

## To Do:

- [x] Allow a language prefix to be added to `home`

