### PR TITLE
fix(home): recent save regression

### DIFF
--- a/src/connectors/items/items-saved.state.js
+++ b/src/connectors/items/items-saved.state.js
@@ -4,6 +4,7 @@ import { getSavedItemsTagged } from 'common/api/queries/get-saved-items-tagged'
 import { getSavedItemsSearch } from 'common/api/queries/get-saved-items-search'
 
 import { deriveSavedItem } from 'common/api/derivers/item'
+import { STARTER_ARTICLES } from 'common/constants'
 
 import { ITEMS_SAVED_REQUEST } from 'actions'
 import { ITEMS_SAVED_SUCCESS } from 'actions'
@@ -90,7 +91,9 @@ function* savedItemRequest(action) {
     if (!pageInfo) return yield put({ type: ITEMS_SAVED_PAGE_INFO_FAILURE })
     if (!edges) return yield put({ type: ITEMS_SAVED_FAILURE })
 
-    const savedItemIds = edges.map((edge) => edge.node.id)
+    const savedItemIds = edges
+      .filter((edge) => !STARTER_ARTICLES.includes(edge.node.item.resolvedId)) //!! While we remove this item from being added by backend
+      .map((edge) => edge.node.id)
     const nodes = edges.reduce(getNodeFromEdge, {})
     const itemsById = edges.reduce(getItemFromEdge, {})
     const itemsCount = savedItemIds.length


### PR DESCRIPTION
## Goal
This PR is mean to omit the welcome message from a users list until we can get it removed by the backend.  It is currently hindering user testing.

## To Do:

- [x] Omit starter article 

## Implementation Decisions

Slack conversations around this item being directly injected into users list and how that should be sunsetted as the collection is out of date and there are better opportunities here.

(note this is based on resolvedId so the deriver work at #925 will need to be adjusted so as to not kill that value)