### PR TITLE
feat(collections): use label for collections homepage

### DIFF
--- a/src/pages/collections/index.js
+++ b/src/pages/collections/index.js
@@ -17,7 +17,7 @@ export const getStaticProps = wrapper.getStaticProps((store) => async ({ locale 
     locale
   }
 
-  const labels = locale === 'en-KE' ? ['region-east-africa'] : null
+  const labels = locale === 'en-KE' ? ['region-east-africa'] : ['collections-homepage']
 
   // Hydrating initial state with an async request. This will block the
   // page from loading. Do this for SEO/crawler purposes


### PR DESCRIPTION
## Goal

Adding a label that will limit the collections we get for the collection surface

## To Do:

- [x] add `collections-homepage` label on the base collections request

## Implementation Decisions
![giphy-1](https://user-images.githubusercontent.com/16119672/217742316-a3944828-d752-4a77-8155-f8ea858f33db.gif)
