### PR TITLE
fix(item): remove scroll into view on focus [DIS-381]

### DIFF
--- a/src/components/item/item.js
+++ b/src/components/item/item.js
@@ -104,7 +104,6 @@ export const Item = (props) => {
     if (notSelectedAndActive) linkRef.current.blur()
     if (selectedAndNotActive) {
       linkRef.current.focus()
-      footerRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' })
     }
   }, [shortcutSelected, linkRef])
 


### PR DESCRIPTION
## Goal

When a user clicked on the overflow menu in grid view, it scrolled them into view and destroyed the menu.  This removes the explicit `scrollIntoView` since the browser handles that naturally on focus. 

## To Do:

- [x] Remove explicit scrollIntoView

## Implementation Decisions

This was put into place for bulk edit (where the browser doesn't handle it as well), but it feels like something we should revisit and fix there.  This functionality came from the last `item` code ... so want to take a deeper look.  But this fixes the immediate problem in production that is a bad user experience.
