### PR TITLE
fix(saves): update banner copy to say Collections instead of lists

### DIFF
--- a/src/components/call-out/call-out-collections.js
+++ b/src/components/call-out/call-out-collections.js
@@ -84,7 +84,7 @@ export function CallOutCollection() {
         </svg>
         <p>
           <Trans i18nKey="collections:call-out-body">
-            Take the guesswork out of your next great read. Pocket lists put the best of the
+            Take the guesswork out of your next great read. Pocket Collections put the best of the
             internet at your fingertips.
           </Trans>
         </p>


### PR DESCRIPTION
## Goal

Simple PR. See https://pocket.slack.com/archives/C04J6VCM49J/p1677172774677759?thread_ts=1677070800.511129&cid=C04J6VCM49J

## To Do:

- [x] Select text
- [x] Cmd+c
- [x] Select text
- [x] Cmd+v

