### PR TITLE
fix(lists): dont render modals unless showmodal prop is true

### DIFF
--- a/src/connectors/confirm/create-list.js
+++ b/src/connectors/confirm/create-list.js
@@ -21,7 +21,7 @@ export const CreateListModal = () => {
 
   const createList = (id) ? 'Create list with item' : 'Create list'
 
-  return (
+  return showModal ? (
     <CreateEditShareableList
       showModal={showModal}
       modalTitle={createList}
@@ -29,5 +29,5 @@ export const CreateListModal = () => {
       handleClose={handleClose}
       handleSubmit={handleSubmit}
     />
-  )
+  ) : null
 }

--- a/src/connectors/confirm/list-settings.js
+++ b/src/connectors/confirm/list-settings.js
@@ -25,7 +25,7 @@ export const ListSettingsModal = ({ id }) => {
     // snowplow event
   }
 
-  return (
+  return showModal ? (
     <CreateEditShareableList
       showModal={showModal}
       modalTitle="List Settings"
@@ -35,5 +35,5 @@ export const ListSettingsModal = ({ id }) => {
       handleClose={handleClose}
       handleSubmit={handleSubmit}
     />
-  )
+  ) : null
 }


### PR DESCRIPTION
## Goal

If we don't render the modal at all if we don't need to, then it allows the default values the chance to reset

## To Do:

- [x] Don't render modal unless `showModal` is true

## Implementation Decisions

Easiest way to make sure all the values are appropriately reset