### PR TITLE
fix(reader): "back to saves" and archive should always take you back to saves

### DIFF
--- a/src/components/reader/nav.js
+++ b/src/components/reader/nav.js
@@ -158,9 +158,7 @@ export const ReaderNav = ({
   const { getStarted } = router.query
 
   const goBack = () => {
-    if (getStarted) return router.push('/home')
-    if (window.history.length > 1) return window.history.go(-1)
-    document.location.href = '/saves'
+    return router.push(getStarted ? '/home' : '/saves')
   }
   const clickGoBack = () => {
     const identifier = getStarted ? 'get-started.reader.gohome' : 'reader.goback'


### PR DESCRIPTION
## Goal

Bug fix - clicking certain buttons (namely "Back to Saves") take user to previous page, which might not be Pocket

## To Do:

- [x] Let's just always send user back to saves instead of previous page