### PR TITLE
fix(lists): adding user to query and other polish

### DIFF
--- a/src/common/api/queries/get-shareable-list-public.js
+++ b/src/common/api/queries/get-shareable-list-public.js
@@ -24,6 +24,10 @@ const getShareableListPublicQuery = gql`
         updatedAt
         url
       }
+      user {
+        username
+        avatarUrl
+      }
     }
   }
 `

--- a/src/components/headers/lists-header.js
+++ b/src/components/headers/lists-header.js
@@ -6,6 +6,7 @@ import { FiltersAltIcon } from 'components/icons/FiltersAltIcon'
 import Avatar from 'components/avatar/avatar'
 import { SaveListButton } from 'components/content-saving/save-list'
 import { ListStatus } from 'components/shareable-lists/list-status'
+import { IosShareIcon } from 'components/icons/IosShareIcon'
 
 const listHeaderStyles = css`
   padding-bottom: 22px;
@@ -132,7 +133,7 @@ export const ListIndividualHeader = ({
       <div className="create-sort">
         {isPublic ? (
           <button onClick={handleShare} className="tiny share">
-            Share list
+            <IosShareIcon /> Share list
           </button>
         ) : null}
 

--- a/src/containers/lists/lists.state.js
+++ b/src/containers/lists/lists.state.js
@@ -73,10 +73,14 @@ export const pageListsInfoReducers = (state = initialState, action) => {
     }
 
     case LIST_CREATE_SUCCESS: {
-      const { newList, externalId } = action
+      const { newList, externalId, listTitle } = action
       return {
         ...state,
-        [externalId]: newList
+        [externalId]: newList,
+        titleToIdList: {
+          [listTitle]: externalId,
+          ...state.titleToIdList
+        }
       }
     }
 

--- a/src/containers/public-list/public-list.js
+++ b/src/containers/public-list/public-list.js
@@ -18,7 +18,7 @@ export const PublicList = ({ listId, slug, statusCode }) => {
   if (statusCode) return <ErrorPage statusCode={statusCode} />
   if (!list) return null
 
-  const { title, description, listItems } = list
+  const { title, description, listItems, user } = list
   const showLists = listItems?.length
   const saveStatus = saveItemId ? 'saved' : 'unsaved'
   const url = `${BASE_URL}/sharedlists/${listId}/${slug}`
@@ -46,13 +46,12 @@ export const PublicList = ({ listId, slug, statusCode }) => {
       <Layout
         title={title}
         metaData={metaData}
-        forceWebView={true}
       >
         <ListPublicHeader
           title={title}
           description={description}
-          // avatarUrl={avatarUrl}
-          // userName={userName}
+          avatarUrl={user?.avatarUrl}
+          userName={user?.userName}
           listCount={listItems?.length}
           isAuthenticated={isAuthenticated}
           saveStatus={saveStatus}


### PR DESCRIPTION
## Goal

The user has been added to the query. There is no data returned yet, but once there is it should automagically work.

## To Do:

- [x] Add user to public list query
- [x] pass through user data to public list header
- [x] Add share icon to share button
- [x] Updating title list store on list creation
- [x] Remove force web view from public lists

## Implementation Decisions

Tweaks and stuff