### PR TITLE
fix(lists): update lists for mobile screens [OSL-274]

### DIFF
--- a/src/components/headers/lists-header.js
+++ b/src/components/headers/lists-header.js
@@ -8,6 +8,7 @@ import { SaveListButton } from 'components/content-saving/save-list'
 import { ListStatus } from 'components/shareable-lists/list-status'
 import { IosShareIcon } from 'components/icons/IosShareIcon'
 import { ListStatusToggle } from 'components/shareable-lists/list-status-toggle'
+import { breakpointSmallTablet } from 'common/constants'
 
 const listHeaderStyles = css`
   padding-bottom: 22px;
@@ -46,6 +47,21 @@ const listHeaderStyles = css`
       height: 1.875rem;
       padding: 0 12px;
       cursor: pointer;
+    }
+  }
+
+  ${breakpointSmallTablet} {
+    &.list-individual {
+      flex-direction: column;
+
+      .create-sort {
+        margin-top: 12px;
+      }
+
+      .headline a {
+        display: block;
+        margin: 8px 0 0 0;
+      }
     }
   }
 `
@@ -120,7 +136,7 @@ export const ListIndividualHeader = ({
   const isPublic = status === 'PUBLIC'
 
   return (
-    <header className={cx(savesHeaderStyle, listHeaderStyles)}>
+    <header className={cx(savesHeaderStyle, listHeaderStyles, 'list-individual')}>
       <div className="headline">
         <h1 className="pageTitle" data-cy="page-title">
           {title}

--- a/src/components/shareable-lists/add-to-list-modal.js
+++ b/src/components/shareable-lists/add-to-list-modal.js
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { css } from 'linaria'
 import { Modal, ModalBody, ModalFooter } from 'components/modal/modal'
 import { AddIcon } from 'components/icons/AddIcon'
+import { breakpointMediumHandset } from 'common/constants'
 
 const footerStyles = css`
   display: flex;
@@ -10,6 +11,10 @@ const footerStyles = css`
   .create {
     margin-left: 0;
     color: var(--color-actionPrimary);
+
+    ${breakpointMediumHandset} {
+      padding: 0;
+    }
   }
 `
 


### PR DESCRIPTION
## Goal

update lists for mobile screens

## To Do:

- [x] Update individual list header
- [x] Update button spacing on Add to List modal

## Implementation Decisions

<img width="373" alt="image" src="https://user-images.githubusercontent.com/1273879/226471268-fa3ca06d-01d3-4542-bc89-7fe5919bbc50.png">

<img width="376" alt="image" src="https://user-images.githubusercontent.com/1273879/226471392-14a5dfad-f5d7-46c9-bfe9-b60ae45f3955.png">
