### PR TITLE
fix(add/create list items): if no thumbnail pass null instead of false [OSL-271]

### DIFF
--- a/src/connectors/lists/mutation-add.state.js
+++ b/src/connectors/lists/mutation-add.state.js
@@ -76,7 +76,7 @@ function* listAddItem({ id }) {
     const data = {
       url: givenUrl,
       excerpt,
-      imageUrl: thumbnail ? thumbnail : null,
+      imageUrl: thumbnail || null,
       title,
       publisher,
       listExternalId: externalId

--- a/src/connectors/lists/mutation-create.state.js
+++ b/src/connectors/lists/mutation-create.state.js
@@ -80,7 +80,7 @@ function* itemsCreateList({ id }) {
       listItemData = {
         url: givenUrl,
         excerpt,
-        imageUrl: thumbnail ? thumbnail : null,
+        imageUrl: thumbnail || null,
         title,
         publisher,
         sortOrder: 1


### PR DESCRIPTION
## Goal
Fixes an issue when adding an item with no thumbnail to a list. See the ticket for more details.

[OSL-271](https://getpocket.atlassian.net/browse/OSL-271)



[OSL-271]: https://getpocket.atlassian.net/browse/OSL-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ