### PR TITLE
fix(analytics): move gtm to outside custom document

### DIFF
--- a/src/connectors/third-party/third-party-init.js
+++ b/src/connectors/third-party/third-party-init.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useDispatch } from 'react-redux'
+import Script from 'next/script'
 
 import { pageview } from 'common/utilities/analytics/ga'
 import { loadOptinMonster } from 'common/utilities/third-party/opt-in-monster'
@@ -154,5 +155,18 @@ export function ThirdPartyInit() {
     }
   }, [router.events, dispatch])
 
-  return <></>
+  return <>
+    {/* put Scripts here instead of in Next Head  */}
+    {/* Google Tag Manager */}
+    <Script id="google-tag-manager">
+      {`
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-P4LPJ42');
+      `}
+    </Script>
+    {/* End Google Tag Manager */}
+  </>
 }

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,5 +1,4 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
-import Script from 'next/script'
 import { COLOR_MODE_PREFIX, CACHE_KEY_COLOR_MODE } from 'common/constants'
 import { GOOGLE_ANALYTICS_ID } from 'common/constants'
 
@@ -9,18 +8,6 @@ class ClientDocument extends Document {
       <Html>
         {/* prettier-ignore */}
         <Head>
-          {/* Google Tag Manager */}
-          <Script id="google-tag-manager">
-            {`
-              (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-              new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-              })(window,document,'script','dataLayer','GTM-P4LPJ42');
-            `}
-          </Script>
-          {/* End Google Tag Manager */}
-
           {/* Loads an iOS app store banner at the top of Safari */}
           <meta name="apple-itunes-app" content="app-id=309601447" />
 


### PR DESCRIPTION
## Goal

GTM still isn't working and today reports a big enough discrepancy in activity to warrant investigating our implementation again. Found [this Stackoverflow](https://stackoverflow.com/questions/68058814/next-11-and-adding-script-tags-not-working-no-scripts-are-rendered) , which says we need to simply move our placement of the GTM script

## To Do:

- [x] Kick GTM script to outside `document.js`
- [x] Figure out where exactly to put GTM script
