### PR TITLE
fix(list items): include itemId when adding & creating

### DIFF
--- a/src/common/api/mutations/createShareableListItem.js
+++ b/src/common/api/mutations/createShareableListItem.js
@@ -17,7 +17,15 @@ const createShareableListItemQuery = gql`
     }
   }
 `
-export function createShareableListItem({ url, excerpt, imageUrl, title, listExternalId, publisher }) {
+export function createShareableListItem({
+  url,
+  excerpt,
+  imageUrl,
+  title,
+  listExternalId,
+  publisher,
+  itemId
+}) {
   const data = {
     excerpt,
     imageUrl,
@@ -25,6 +33,7 @@ export function createShareableListItem({ url, excerpt, imageUrl, title, listExt
     url,
     listExternalId,
     publisher,
+    itemId,
     sortOrder: 1
   }
 

--- a/src/connectors/lists/mutation-add.state.js
+++ b/src/connectors/lists/mutation-add.state.js
@@ -71,9 +71,10 @@ function* listAddItem({ id }) {
 
   try {
     const { externalId, listTitle } = confirm
-    const { givenUrl, excerpt, thumbnail, title, publisher } = yield select(getItem, id)
+    const { givenUrl, excerpt, thumbnail, title, publisher, itemId } = yield select(getItem, id)
 
     const data = {
+      itemId,
       url: givenUrl,
       excerpt,
       imageUrl: thumbnail || null,

--- a/src/connectors/lists/mutation-create.state.js
+++ b/src/connectors/lists/mutation-create.state.js
@@ -76,13 +76,14 @@ function* itemsCreateList({ id }) {
     // If item is null, that means an id was never passed in, so listItemData will
     // remain null, which means it'll create a list without the item.
     if (item) {
-      const { givenUrl, excerpt, thumbnail, title, publisher } = item
+      const { givenUrl, excerpt, thumbnail, title, publisher, itemId } = item
       listItemData = {
         url: givenUrl,
         excerpt,
         imageUrl: thumbnail || null,
         title,
         publisher,
+        itemId,
         sortOrder: 1
       }
     }


### PR DESCRIPTION
## Goal

We were erroneously not passing through `itemId` for list items when adding them to a list or creating a list with an item. This fixes that. There was no user impact with us not passing this through, but it is necessary for backend purposes.

## To Do:

- [x] Include `itemId` in our list item data

