### PR TITLE
fix(recent-saves): remove logic to show recent saves at bottom [DIS-514]

### DIFF
--- a/src/components/section-wrapper/section-wrapper.js
+++ b/src/components/section-wrapper/section-wrapper.js
@@ -22,18 +22,6 @@ const sectionWrapperStyle = css`
 
   &.homeSection {
     padding-top: 4.25rem;
-    &.first-section {
-      padding-top: 0;
-    }
-  }
-
-  &.bottom {
-    padding-top: 4.25rem;
-    padding-bottom: 1rem;
-    .inner {
-      padding-top: 3rem;
-      border-top: var(--dividerStyle);
-    }
   }
 
   &.slideSection .inner {

--- a/src/containers/home/content.js
+++ b/src/containers/home/content.js
@@ -63,8 +63,6 @@ function StaticSlate({ slateId, firstSlate }) {
   const viewport = useViewport()
   const dispatch = useDispatch()
   const slate = useSelector((state) => state.pageHome.slatesById[slateId])
-  const featureState = useSelector((state) => state.features) || {}
-  const recentsTest = featureFlagActive({ flag: 'home.recents', featureState })
 
   const { headline, subheadline, moreLink, recommendations, recommendationReasonType } = slate
 
@@ -89,7 +87,7 @@ function StaticSlate({ slateId, firstSlate }) {
 
   return (
     <SectionWrapper
-      className={cx('homeSection', firstSlate && recentsTest && 'first-section')}
+      className="homeSection"
       data-cy={`home-section-${testId}`}>
       <HomeHeader
         headline={headline}

--- a/src/containers/home/home.js
+++ b/src/containers/home/home.js
@@ -9,7 +9,6 @@ import { HomeSetup } from './setup/setup'
 
 import { useRouter } from 'node_modules/next/router'
 import { BannerGermanHome } from 'components/banner/german-home'
-import { featureFlagActive } from 'connectors/feature-flags/feature-flags'
 import { HomeGreeting } from './recent-saves/greeting'
 
 export const Home = ({ metaData }) => {
@@ -20,7 +19,6 @@ export const Home = ({ metaData }) => {
   const userStatus = useSelector((state) => state.user.user_status)
   const featureState = useSelector((state) => state.features) || {}
 
-  const recentsTest = featureFlagActive({ flag: 'home.recents', featureState })
   const shouldRender = userStatus !== 'pending' && featureState.flagsReady
   if (!shouldRender) return null
 
@@ -31,9 +29,8 @@ export const Home = ({ metaData }) => {
 
       <HomeSetup />
       <HomeGreeting />
-      {recentsTest ? null : <HomeRecentSaves />}
+      <HomeRecentSaves />
       <HomeContent />
-      {recentsTest ? <HomeRecentSaves isBottom={true} /> : null}
     </Layout>
   )
 }

--- a/src/containers/home/recent-saves/greeting.js
+++ b/src/containers/home/recent-saves/greeting.js
@@ -10,8 +10,7 @@ const homeGreeting = css`
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.2;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
+  padding: 2.5rem 0 1rem;
 `
 
 export const HomeGreeting = () => {

--- a/src/containers/home/recent-saves/recent-saves.js
+++ b/src/containers/home/recent-saves/recent-saves.js
@@ -9,7 +9,7 @@ import { sendSnowplowEvent } from 'connectors/snowplow/snowplow.state'
 import { ItemCard } from 'connectors/items/item-card-transitional'
 import { SectionWrapper } from 'components/section-wrapper/section-wrapper'
 
-export const HomeRecentSaves = ({ isBottom }) => {
+export const HomeRecentSaves = () => {
   const { t } = useTranslation()
   const dispatch = useDispatch()
   const recentSaves = useSelector((state) => state.pageSavedIds)
@@ -24,9 +24,7 @@ export const HomeRecentSaves = ({ isBottom }) => {
   }, [dispatch])
 
   return recentSaves?.length > 0 ? (
-    <SectionWrapper
-      className={cx(isBottom && 'bottom')}
-      data-cy='home-section-recent-saves'>
+    <SectionWrapper data-cy='home-section-recent-saves'>
 
       <HomeHeader
         headline={t('home:recent-saves-title', 'Recent Saves')}


### PR DESCRIPTION
## Goal

Clean out code that powered the Discover experiment for previously moving Recent Saves (see https://github.com/Pocket/web-client/pull/969/files)

## To Do:

- [x] Clean up

## Implementation Decisions

We are preserving the compartmentalizing of `HomeGreeting` from `HomeRecentSaves`

However, am reverting the top padding from before the experiment

<img width="670" alt="image" src="https://user-images.githubusercontent.com/14023085/228659993-c3972d8c-138c-436c-8c4e-3332d31ac806.png">
