### PR TITLE
fix(lists): bring back itemId for list items

### DIFF
--- a/src/common/api/mutations/createShareableListItem.js
+++ b/src/common/api/mutations/createShareableListItem.js
@@ -17,7 +17,15 @@ const createShareableListItemQuery = gql`
     }
   }
 `
-export function createShareableListItem({ url, excerpt, imageUrl, title, listExternalId, publisher }) {
+export function createShareableListItem({
+  url,
+  excerpt,
+  imageUrl,
+  title,
+  listExternalId,
+  publisher,
+  itemId
+}) {
   const data = {
     excerpt,
     imageUrl,
@@ -25,6 +33,7 @@ export function createShareableListItem({ url, excerpt, imageUrl, title, listExt
     url,
     listExternalId,
     publisher,
+    itemId,
     sortOrder: 1
   }
 

--- a/src/connectors/lists/mutation-add.state.js
+++ b/src/connectors/lists/mutation-add.state.js
@@ -71,7 +71,7 @@ function* listAddItem({ id }) {
 
   try {
     const { externalId, listTitle } = confirm
-    const { givenUrl, excerpt, thumbnail, title, publisher } = yield select(getItem, id)
+    const { givenUrl, excerpt, thumbnail, title, publisher, itemId } = yield select(getItem, id)
 
     const data = {
       url: givenUrl,
@@ -79,6 +79,7 @@ function* listAddItem({ id }) {
       imageUrl: thumbnail || null,
       title,
       publisher,
+      itemId,
       listExternalId: externalId
     }
 

--- a/src/connectors/lists/mutation-create.state.js
+++ b/src/connectors/lists/mutation-create.state.js
@@ -76,13 +76,14 @@ function* itemsCreateList({ id }) {
     // If item is null, that means an id was never passed in, so listItemData will
     // remain null, which means it'll create a list without the item.
     if (item) {
-      const { givenUrl, excerpt, thumbnail, title, publisher } = item
+      const { givenUrl, excerpt, thumbnail, title, publisher, itemId } = item
       listItemData = {
         url: givenUrl,
         excerpt,
         imageUrl: thumbnail || null,
         title,
         publisher,
+        itemId,
         sortOrder: 1
       }
     }


### PR DESCRIPTION
## Goal

Now that we have the [backend changes](https://github.com/Pocket/shareable-lists-api/pull/135) in place to convert `itemId` to a string (via a [Scalar ID](https://studio.apollographql.com/graph/pocket-client-api/variant/current/schema/reference/scalars/ID)), we need to pass `itemId` when creating list with items or adding items to lists because it is now required.

