### PR TITLE
fix(ListIndividual): update the page when listItemIds changes [OSL-320]

### DIFF
--- a/src/containers/lists/list-individual/list-individual.js
+++ b/src/containers/lists/list-individual/list-individual.js
@@ -32,7 +32,7 @@ export const ListIndividual = () => {
 
   useEffect(() => {
     if (enrolled) dispatch(getIndividualListAction(id))
-  }, [dispatch, id, enrolled])
+  }, [dispatch, id, enrolled, listItemIds])
 
   if (!list) return null
   const { title, description, slug, status, listItemIds: listItemCount, analyticsData } = list


### PR DESCRIPTION
## Goal

Fixes an issue where the empty list illustration would not show up automatically after removing all of the items from a list - it required a page refresh in order to show up.
[OSL-320](https://getpocket.atlassian.net/browse/OSL-320)

🍋 

[OSL-320]: https://getpocket.atlassian.net/browse/OSL-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ