### PR TITLE
fix(saves): fix bad identifier for card Publisher [FRONT-2151]

### DIFF
--- a/src/connectors/items/item-card-saved.js
+++ b/src/connectors/items/item-card-saved.js
@@ -73,7 +73,7 @@ export function ItemCard({
 
   const onOpenOriginalUrl = () => {
     const data = { ...analyticsData, destination: 'external' }
-    dispatch(sendSnowplowEvent(`${snowplowId}.view-original`, data))
+    dispatch(sendSnowplowEvent(`${snowplowId}.card.view-original`, data))
   }
 
   const onItemInView = (inView) => {


### PR DESCRIPTION
## Goal

Fix snowplow event not firing

<img width="334" alt="image" src="https://user-images.githubusercontent.com/14023085/228950256-1cdf3af3-93bf-40f9-884e-bee398ae1b23.png">


## To Do:

- [x] Find out why existing `dispatch()` isn't working
- [x] Correct the identifier
