### PR TITLE
fix(SavesHeader): hide Create List button when in Bulk Edit mode [OSL-340]

### DIFF
--- a/src/components/headers/saves-header.js
+++ b/src/components/headers/saves-header.js
@@ -80,7 +80,8 @@ export const SavesHeader = ({
   handleNewest,
   handleOldest,
   inListsExperiment,
-  handleCreateList
+  handleCreateList,
+  inBulkEdit
 }) => {
   const { t } = useTranslation()
 
@@ -94,6 +95,8 @@ export const SavesHeader = ({
     tags: t('headers:tags', 'Tags')
   }
 
+  const showCreateList = inListsExperiment && !inBulkEdit && subset !== 'tag-page'
+
   return subset ? (
     <header className={savesHeaderStyle}>
       <h1 className="pageTitle" data-cy="page-title">
@@ -101,7 +104,7 @@ export const SavesHeader = ({
       </h1>
       <FilterMenu subset={subset} filter={filter} />
 
-      {subset !== 'tag-page' && inListsExperiment ? (
+      {showCreateList ? (
         <div className="create-list">
           <button onClick={handleCreateList} className="tiny">
             <PlaylistAddIcon /> Create List

--- a/src/containers/saves/saves.js
+++ b/src/containers/saves/saves.js
@@ -43,6 +43,7 @@ export const Saves = (props) => {
   const featureState = useSelector((state) => state.features)
   const isPremium = useSelector((state) => state.user.premium_status === '1')
   const total = useSelector((state) => state.pageSavedInfo.totalCount)
+  const inBulkEdit = useSelector((state) => state?.app?.mode === 'bulk')
   const inListsExperiment = useSelector((state) => state.pageListsInfo.enrolled)
 
   // Derived Values
@@ -80,6 +81,7 @@ export const Saves = (props) => {
           handleRelevance={handleRelevance}
           inListsExperiment={inListsExperiment}
           handleCreateList={handleCreateList}
+          inBulkEdit={inBulkEdit}
         />
         {flagsReady && shouldRender ? <SavedItems {...props} /> : null}
       </main>


### PR DESCRIPTION
## Goal

Hide the Create List button in the Saves header when the user is in Bulk Edit mode
[OSL-340](https://getpocket.atlassian.net/browse/OSL-340)


![bulk-edit](https://user-images.githubusercontent.com/2893463/229630411-3b5e6fee-1d45-41b0-a8c7-2eeff285e1d0.gif)


[OSL-340]: https://getpocket.atlassian.net/browse/OSL-340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ