### PR TITLE
[DRAFT] fix(analytics): remove GT script for UA

### DIFF
--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -46,11 +46,6 @@ class ClientDocument extends Document {
           {/* <!-- OneTrust Cookies Consent Notice end for getpocket.com --> */}
 
           <script
-            async
-            src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID}`}
-          />
-
-          <script
             dangerouslySetInnerHTML={{
               __html: `
             window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
## Goal

Solve an issue around possible duplicate page views in old analytics

We're still seeing a big discrepancy in raw page views between old and new analytics. Something interesting is that syndicated articles in new analytics have an almost 1:1 ratio between page view and its `Users` count, while old analytics have an almost 2:1 ratio between page views and its `Unique Pageviews` count.

While `Users` and `Unique Pageviews` are not necessarily the same, Kenny suggests that the 1:1 ratio is correct (who revisits syndicated articles, am I right?). That would mean something is wrong with Universal Analytics.

![image](https://user-images.githubusercontent.com/14023085/229635535-f9f80b45-6909-4547-99bd-b25139f7d11c.png)

Looking back at historical, the 2:1 ratio started on January 9th. There were analytics PRs merged in on [Jan 9](https://github.com/Pocket/web-client/pull/884) and [Jan 10](https://github.com/Pocket/web-client/pull/883), so it's reasonable to assume we need to revert something from one of them.


## To Do:

- [x] Remove script

## Implementation Decisions

Implemented based on Joel's request