### PR TITLE
fix(waypoint): add response to waypoint error

### DIFF
--- a/src/pages/waypoint.js
+++ b/src/pages/waypoint.js
@@ -46,7 +46,7 @@ export async function getServerSideProps({ req, locale, query, defaultLocale, lo
 
     const response = await getUserInfo(true, req?.headers?.cookie)
     const { user_id, birth = userStartDate } = response?.user || {}
-    if (!user_id && !skipUserCheck) throw new WaypointNoUserIdError()
+    if (!user_id && !skipUserCheck) throw new WaypointNoUserIdError(response)
 
     // Not logged in, or something else went awry?
     // !! NOTE: this will redirect to Saves 100% of the time on localhost unless you use `skipUserCheck=true` in the url


### PR DESCRIPTION
## Goal

Berry smol PR to add in response data to waypoint error. We are currently at 709k errors and it doesn't make sense to continue with that error.  When looking at the cookies, it seems like users are auth'ed.  But they have no userId.  Adding the response to the error message may help us suss out why an authenticated user wouldn't have a user_id.

## To Do:

- [x] Add server response to thrown error

## Implementation Decisions

This will be temporary with an eye to either:

a) handle this with more discrete context to Sentry
b) remove this sentry error entirely and handle it gracefully and silently