### PR TITLE
fix(saves): handle null nodes returned from server

### DIFF
--- a/src/connectors/items/items-saved.state.js
+++ b/src/connectors/items/items-saved.state.js
@@ -160,10 +160,11 @@ function* savedItemSearchRequest(action) {
 /** ASYNC Functions
  --------------------------------------------------------------- */
 
-// Remove any edges that don'e have a node containing and item
+// Remove any edges that do not have a node containing an item
 const validateEdge = (edge) => !!edge?.node?.item
 
-// !!Remove any articles that are part of our legacy starter articles until done by backend
+// !! Remove any articles that are part of our legacy starter articles
+// !! This will be on handled by the backend in future
 const removeStarterArticle = (edge) => !STARTER_ARTICLES.includes(edge?.node?.item?.resolvedId)
 
 const getNodeFromEdge = (previous, current) => {


### PR DESCRIPTION
## Goal

If a list ends up with a `null` saved node in the edge we get back from the server (unclear how this happens at this point) saves page will silently fail.

This fixes that.

## To Do:

- [x] Filter out bad data from saved edges response

## Implementation Decisions

Would love to know how this happens on the graph side of things.  @kschelonka any ideas?