### PR TITLE
fix(lists): prevent empty string from being submitted as a description

### DIFF
--- a/src/connectors/lists/mutation-create.state.js
+++ b/src/connectors/lists/mutation-create.state.js
@@ -1,5 +1,6 @@
 import { put, takeLatest, take, race, call, select } from 'redux-saga/effects'
 import { createShareableList } from 'common/api/mutations/createShareableList'
+import { getObjectWithValidKeysOnly } from 'common/utilities/object-array/object-array'
 
 import { LIST_ITEMS_SUCCESS } from 'actions'
 
@@ -65,10 +66,10 @@ function* itemsCreateList({ id }) {
 
   try {
     const { title, description } = confirm
-    const listData = {
+    const listData = getObjectWithValidKeysOnly({
       title: title.trim(),
       description: description.trim()
-    }
+    })
 
     let listItemData = null
 

--- a/src/connectors/lists/mutation-update.state.js
+++ b/src/connectors/lists/mutation-update.state.js
@@ -1,5 +1,6 @@
 import { put, takeLatest, take, race, call, select } from 'redux-saga/effects'
 import { updateShareableList } from 'common/api/mutations/updateShareableList'
+import { getObjectWithValidKeysOnly } from 'common/utilities/object-array/object-array'
 
 import { LIST_UPDATE_REQUEST } from 'actions'
 import { LIST_UPDATE_CONFIRM } from 'actions'
@@ -68,11 +69,11 @@ function* listUpdate({ id }) {
   try {
     const { title, description } = confirm
 
-    const data = {
+    const data = getObjectWithValidKeysOnly({
       externalId: id,
       description: description.trim(),
       title: title.trim()
-    }
+    })
 
     const response = yield call(updateShareableList, data)
     yield put({ type: LIST_UPDATE_SUCCESS })


### PR DESCRIPTION
## Goal

The API can no longer handle empty strings in the description field. A conversation needs to happen with backend about this, but until then if you try to create list without a description it will fail

## To Do:

- [x] Prevent submission of empty description when creating list
- [x] Prevent submission of empty description when updating list

## Implementation Decisions

🍰 