### PR TITLE
fix(saves): cleanup and remove unused values

### DIFF
--- a/src/common/api/_legacy/messages.js
+++ b/src/common/api/_legacy/messages.js
@@ -44,7 +44,6 @@ function modernizeItem(node) {
     resolved_title,
     resolved_url,
     excerpt,
-    word_count,
     domain_metadata,
     authors,
     image,
@@ -52,13 +51,11 @@ function modernizeItem(node) {
     ...rest
   } = item
 
-
   const convertedItem = {
     itemId: item_id || resolved_id,
     title: resolved_title || given_url,
     excerpt,
     resolvedTitle: resolved_title,
-    wordCount: word_count,
     itemImage: image?.src,
     domainMetadata: domain_metadata,
     givenUrl: given_url,

--- a/src/common/api/derivers/collection/home.spec.js
+++ b/src/common/api/derivers/collection/home.spec.js
@@ -14,8 +14,6 @@ const collectionAsItem = {
   isArticle: false,
   title: 'Going Down the Rabbit Hole: Why People Fall for Conspiracy Theories',
   itemId: '3664844706',
-  normalUrl:
-    'http://getpocket.com/collections/going-down-the-rabbit-hole-why-people-fall-for-conspiracy-theories',
   resolvedId: '3664844706',
   resolvedUrl:
     'https://getpocket.com/collections/going-down-the-rabbit-hole-why-people-fall-for-conspiracy-theories',
@@ -40,7 +38,6 @@ const collectionAsItem = {
   ],
   topImageUrl:
     'https://pocket-image-cache.com/1200x/filters:format(jpg):extract_focal()/https%3A%2F%2Fs3.amazonaws.com%2Fpocket-collectionapi-prod-images%2Fc3d81de1-7e57-4393-ab61-6323c061c2ef.png',
-  wordCount: 0,
   timeToRead: null,
   givenUrl:
     'http://getpocket.com/collections/going-down-the-rabbit-hole-why-people-fall-for-conspiracy-theories',

--- a/src/common/api/derivers/collection/story.spec.js
+++ b/src/common/api/derivers/collection/story.spec.js
@@ -27,7 +27,6 @@ export const storyFromClientApi = {
       }
     ],
     itemId: '1731163180',
-    normalUrl: 'http://nytimes.com/2017/05/06/business/inside-vws-campaign-of-trickery.html',
     resolvedId: '1731163180',
     resolvedUrl: 'https://www.nytimes.com/2017/05/06/business/inside-vws-campaign-of-trickery.html',
     domain: null,
@@ -76,7 +75,6 @@ export const storyFromClientApi = {
     ],
     topImageUrl:
       'https://static01.nyt.com/images/2017/05/07/business/07vwexcerpt1-web/07vwexcerpt1-web-facebookJumbo.jpg?year=2017&h=549&w=1050&s=9040da8dc525be00827fd1625a9bb1e954d7d895d974cec2d8a8395682209f60&k=ZQJBKqZ0VN',
-    wordCount: 2975,
     timeToRead: 14,
     givenUrl: 'https://www.nytimes.com/2017/05/06/business/inside-vws-campaign-of-trickery.html',
     syndicatedArticle: null

--- a/src/common/api/derivers/discover/discover.spec.js
+++ b/src/common/api/derivers/discover/discover.spec.js
@@ -37,8 +37,6 @@ export const recommendationsFromSlate = {
     isArticle: true,
     title: 'Apple is ready to admit it was wrong about the future of laptops',
     itemId: '3460462323',
-    normalUrl:
-      'http://theverge.com/22734645/apple-macbook-pro-2021-ports-magsafe-touch-bar-usb-c-future',
     resolvedId: '3460462323',
     resolvedUrl:
       'https://www.theverge.com/22734645/apple-macbook-pro-2021-ports-magsafe-touch-bar-usb-c-future',
@@ -96,7 +94,6 @@ export const recommendationsFromSlate = {
     topImageUrl:
       'https://cdn.vox-cdn.com/thumbor/26f5VRT9jvt6JW6WB4Nohu849cI=/0x137:1911x1138/fit-in/1200x630/cdn.vox-cdn.com/uploads/chorus_asset/file/22938855/Apple_MacBook_Pro_Ports_10182021.jpg',
     videos: null,
-    wordCount: 1491,
     dateResolved: '2021-10-27 07:47:47',
     datePublished: '2021-10-19 15:30:00',
     language: 'en',

--- a/src/common/api/derivers/discover/home.spec.js
+++ b/src/common/api/derivers/discover/home.spec.js
@@ -31,8 +31,6 @@ export const recommendationsFromSlate = {
     isArticle: true,
     title: "What You Do With Your Shopping Cart When You're Done With It Says A Lot About You",
     itemId: '3365323914',
-    normalUrl:
-      'http://getpocket.com/explore/item/people-think-what-you-do-with-your-shopping-cart-when-you-re-done-with-it-says-a-lot-about-you',
     resolvedId: '3365323914',
     resolvedUrl:
       'https://getpocket.com/explore/item/people-think-what-you-do-with-your-shopping-cart-when-you-re-done-with-it-says-a-lot-about-you',
@@ -55,7 +53,6 @@ export const recommendationsFromSlate = {
     ],
     topImageUrl:
       'https://pocket-image-cache.com/1200x/filters:format(jpg):extract_focal()/https%3A%2F%2Fhips.hearstapps.com%2Fhmg-prod.s3.amazonaws.com%2Fimages%2Fview-of-branded-shopping-carts-lined-up-on-a-sidewalk-news-photo-1605802464.%3Fresize%3D640%3A*',
-    wordCount: 350,
     timeToRead: null,
     givenUrl:
       'http://getpocket.com/explore/item/people-think-what-you-do-with-your-shopping-cart-when-you-re-done-with-it-says-a-lot-about-you',

--- a/src/common/api/derivers/discover/syndicated.spec.js
+++ b/src/common/api/derivers/discover/syndicated.spec.js
@@ -33,8 +33,6 @@ export const recommendationsFromSlate = {
       }
     ],
     itemId: '2418914954',
-    normalUrl:
-      'http://getpocket.com/explore/item/the-3-minutes-it-takes-to-read-this-will-improve-your-conversations-forever',
     resolvedId: '2418914954',
     resolvedUrl:
       'https://getpocket.com/explore/item/the-3-minutes-it-takes-to-read-this-will-improve-your-conversations-forever',
@@ -58,7 +56,6 @@ export const recommendationsFromSlate = {
     videos: null,
     topImageUrl:
       'https://pocket-image-cache.com/1200x/filters:format(jpg):extract_focal()/https%3A%2F%2Fs3.amazonaws.com%2Fpocket-syndicated-images%2Farticles%2F326%2F1566916077_direct.jpg',
-    wordCount: 579,
     timeToRead: 3,
     givenUrl:
       'http://getpocket.com/explore/item/the-3-minutes-it-takes-to-read-this-will-improve-your-conversations-forever',

--- a/src/common/api/derivers/item.js
+++ b/src/common/api/derivers/item.js
@@ -37,10 +37,8 @@ import { BASE_URL } from 'common/constants'
  * @param {Boolean} isIndex — true if the item is an index / home page, rather than a specific single piece of content
  * @param {String} title — The title as determined by the parser.
  * @param {URL} topImageUrl — The page's / publisher's preferred thumbnail image
- * @param {int} wordCount — Number of words in the article (we use this to derive read time)
  * @param {DateString} datePublished — The date the article was published
  * @param {string} language — The detected language of the article
- * @param {int} timeToRead — How long it will take to read the article (WordCount / 220 WPM)
  * @param {Boolean} fromPartner — If a story is sponsored/partnered
  *
  * INCLUDED ITEM ENRICHMENT

--- a/src/common/api/derivers/list/collection.spec.js
+++ b/src/common/api/derivers/list/collection.spec.js
@@ -49,7 +49,6 @@ export const savedCollectionFromClientApi = {
       topImageUrl:
         'https://pocket-image-cache.com/1200x/filters:format(jpg):extract_focal()/https%3A%2F%2Fs3.amazonaws.com%2Fpocket-collectionapi-prod-images%2F756e1877-8857-45c4-b9f6-84c62a0700b5.png',
       videos: null,
-      wordCount: 388,
       datePublished: null,
       language: 'en',
       timeToRead: null,

--- a/src/common/api/derivers/list/image.spec.js
+++ b/src/common/api/derivers/list/image.spec.js
@@ -37,7 +37,6 @@ export const savedImageFromClientApi = {
       title: '',
       topImageUrl: null,
       videos: null,
-      wordCount: 0,
       datePublished: null,
       language: '',
       timeToRead: null,

--- a/src/common/api/derivers/list/parsed.spec.js
+++ b/src/common/api/derivers/list/parsed.spec.js
@@ -3,55 +3,56 @@ import { analyticsActions } from 'connectors/snowplow/actions'
 import { validateSnowplowExpectations } from 'connectors/snowplow/snowplow.state'
 
 //prettier-ignore
-export const savedParsedFromClientApi =   {
-  "node": {
-      "_createdAt": 1634765628,
-      "_updatedAt": 1634765628,
-      "url": "http://nytimes.com/2021/06/21/well/mind/aging-memory-centenarians.html",
-      "status": "UNREAD",
-      "isFavorite": false,
-      "favoritedAt": null,
-      "isArchived": false,
-      "archivedAt": null,
-      "tags": [],
-      "item": {
-          "itemId": "3362121180",
-          "authors": [
-              {
-                  "name": "JANE E. BRODY",
-                  "url": "https://www.nytimes.com/by/jane-e-brody"
-              }
-          ],
-          "domainMetadata": {
-              "name": "The New York Times",
-              "logo": "https://logo.clearbit.com/nytimes.com?size=800"
-          },
-          "domain": null,
-          "excerpt": "By studying centenarians, researchers hope to develop strategies to ward off Alzheimer’s disease and slow brain aging for all of us.",
-          "hasImage": "HAS_IMAGES",
-          "hasVideo": "NO_VIDEOS",
-          "images": [
-              {
-                  "src": "https://static01.nyt.com/images/2021/06/22/science/21SCI-BRODY-CENTENARIANS/21SCI-BRODY-CENTENARIANS-articleLarge.jpg?quality=75&auto=webp&disable=upscale",
-              },
-          ],
-          "isArticle": true,
-          "isIndex": false,
-          "resolvedUrl": "https://www.nytimes.com/2021/06/21/well/mind/aging-memory-centenarians.html",
-          "resolvedId": "3362121180",
-          "title": "The Secrets of ‘Cognitive Super-Agers’",
-          "topImageUrl": "https://static01.nyt.com/images/2021/06/22/science/21SCI-BRODY-CENTENARIANS/21SCI-BRODY-CENTENARIANS-facebookJumbo.jpg",
-          "videos": null,
-          "wordCount": 1112,
-          "datePublished": "2021-06-21 04:00:09",
-          "language": "en",
-          "timeToRead": 5,
-          "givenUrl": "http://nytimes.com/2021/06/21/well/mind/aging-memory-centenarians.html",
-          "syndicatedArticle": null,
-          "collection": null
-      }
+export const savedParsedFromClientApi = {
+  node: {
+    _createdAt: 1634765628,
+    _updatedAt: 1634765628,
+    url: 'http://nytimes.com/2021/06/21/well/mind/aging-memory-centenarians.html',
+    status: 'UNREAD',
+    isFavorite: false,
+    favoritedAt: null,
+    isArchived: false,
+    archivedAt: null,
+    tags: [],
+    item: {
+      itemId: '3362121180',
+      authors: [
+        {
+          name: 'JANE E. BRODY',
+          url: 'https://www.nytimes.com/by/jane-e-brody'
+        }
+      ],
+      domainMetadata: {
+        name: 'The New York Times',
+        logo: 'https://logo.clearbit.com/nytimes.com?size=800'
+      },
+      domain: null,
+      excerpt:
+        'By studying centenarians, researchers hope to develop strategies to ward off Alzheimer’s disease and slow brain aging for all of us.',
+      hasImage: 'HAS_IMAGES',
+      hasVideo: 'NO_VIDEOS',
+      images: [
+        {
+          src: 'https://static01.nyt.com/images/2021/06/22/science/21SCI-BRODY-CENTENARIANS/21SCI-BRODY-CENTENARIANS-articleLarge.jpg?quality=75&auto=webp&disable=upscale'
+        }
+      ],
+      isArticle: true,
+      isIndex: false,
+      resolvedUrl: 'https://www.nytimes.com/2021/06/21/well/mind/aging-memory-centenarians.html',
+      resolvedId: '3362121180',
+      title: 'The Secrets of ‘Cognitive Super-Agers’',
+      topImageUrl:
+        'https://static01.nyt.com/images/2021/06/22/science/21SCI-BRODY-CENTENARIANS/21SCI-BRODY-CENTENARIANS-facebookJumbo.jpg',
+      videos: null,
+      datePublished: '2021-06-21 04:00:09',
+      language: 'en',
+      timeToRead: 5,
+      givenUrl: 'http://nytimes.com/2021/06/21/well/mind/aging-memory-centenarians.html',
+      syndicatedArticle: null,
+      collection: null
+    }
   },
-  "cursor": "MzM2MjEyMTE4MF8qXzE2MzQ3NjU2Mjg="
+  cursor: 'MzM2MjEyMTE4MF8qXzE2MzQ3NjU2Mjg='
 }
 
 describe('Saves - Parsed', () => {

--- a/src/common/api/derivers/list/unparsed.spec.js
+++ b/src/common/api/derivers/list/unparsed.spec.js
@@ -48,7 +48,6 @@ export const savedUnparsedFromClientApi = {
       topImageUrl:
         'https://www.myswitzerland.com/-/media/st/gadmin/images/accommodation/summer/typically%20swiss/k-img_5780_2_36163.jpg',
       videos: null,
-      wordCount: 260,
       datePublished: null,
       language: 'en',
       timeToRead: null,

--- a/src/common/api/derivers/list/video.spec.js
+++ b/src/common/api/derivers/list/video.spec.js
@@ -56,7 +56,6 @@ export const savedVideoFromClientApi = {
           length: 61
         }
       ],
-      wordCount: 0,
       datePublished: '2019-10-19 06:37:37',
       language: '',
       timeToRead: null,

--- a/src/common/api/fragments/fragment.item.js
+++ b/src/common/api/fragments/fragment.item.js
@@ -5,7 +5,6 @@ export const FRAGMENT_ITEM = gql`
     isArticle
     title
     itemId
-    normalUrl
     resolvedId
     resolvedUrl
     domain
@@ -30,7 +29,6 @@ export const FRAGMENT_ITEM = gql`
       src
     }
     topImageUrl
-    wordCount
     timeToRead
     givenUrl
     collection {


### PR DESCRIPTION
## Goal

Fix saved list being Blank McBlank face for usersd

## To Do:

- [x] Remove `normalURL` (we don't use it)
- [x] Remove `wordCount` (we don't use it)

## Implementation Decisions

Got a clone of a users list and they were getting no pageInfo back due to a normalUrl is non-nullable error from the graph.  My assumption is everything is humming along on the server side, it hits the `normalUrl`, errors out and then doesn't return `pageInfo` ... which means we are a little smackled.

Luckily, we don't use these values ... so removing them fixes it ... BUT ... we should really see about how bad data comes out of the graph and wether all the non-nullable fields are actually non-nullable.

cc: @kschelonka 