### PR TITLE
fix(card): add z-index to card when in hover state [OSL-411]

### DIFF
--- a/src/components/item/item-styles.js
+++ b/src/components/item/item-styles.js
@@ -69,6 +69,7 @@ export const itemStyles = css`
 
   // What happens when we hover over the main card
   &:hover {
+    z-index: 1;
     box-shadow: var(--card-hover-shadow);
 
     // We show a view original to help the user realize they may be leaving the pocket experience


### PR DESCRIPTION
## Goal

When a card menu opens in a downward direction it would appear behind the following cards. This change allows the menu to appear above all surrounding cards.

## To Do:

- [x] Add z-index to cards when hovered

## Implementation Decisions

Confirmed this works on mobile, as clicking the menu button turns on the hover state on the card

<img width="389" alt="image" src="https://user-images.githubusercontent.com/1273879/234089690-39cc68a2-a7bd-429b-8e5b-73ba1aaa5418.png">
