### PR TITLE
feat(listen): redirect to help article [UJM-91]

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -51,6 +51,13 @@ const nextOptions = {
         source: '/collections/page/1',
         destination: '/collections',
         permanent: false
+      },
+      {
+        source: '/listen/:anything*',
+        destination:
+          'https://help.getpocket.com/article/1081-listening-to-articles-in-pocket-with-text-to-speech',
+        permanent: false,
+        basePath: false
       }
     ]
   },


### PR DESCRIPTION
## Goal

Add temporary redirect for `listen/`

## To Do:

- [x] Add redirect for `/listen`

## Implementation Decisions

Mobile will be supporting deep links to `listen` ... while we could do this redirect in `dotcom` I moved it here in case we want to add it to the labs project sooner rather than later.