### PR TITLE
fix(public-list): update alt text on creator avatar [OSL-434]

### DIFF
--- a/src/components/headers/lists-header.js
+++ b/src/components/headers/lists-header.js
@@ -210,6 +210,7 @@ export const ListPublicHeader = ({
   handleShare
 }) => {
   const countText = listCount === 1 ? 'Item' : 'Items'
+  const creator = userName || 'Pocket User'
 
   return (
     <header className={publicListHeaderStyles}>
@@ -219,8 +220,13 @@ export const ListPublicHeader = ({
       </section>
       <section className="list-info">
         <div className="list-user-info">
-          <Avatar src={avatarUrl} size="32px" className="list-user-avatar" />
-          <span>{userName || 'Pocket User'}</span> |{' '}
+          <Avatar
+            src={avatarUrl}
+            size="32px"
+            className="list-user-avatar"
+            altText={`${creator}’s avatar`}
+          />
+          <span>{creator}</span> |{' '}
           <span>
             {listCount} {countText}
           </span>


### PR DESCRIPTION
## Goal

Update the alt text on the avatar on a public list to include the creator's username

## To Do:

- [x] Add creator's name to the alt text on the avatar

## Implementation Decisions

![saymyname](https://user-images.githubusercontent.com/1273879/234665204-783f2a3e-1ae2-4e41-ab6c-0cc3d8179b58.gif)
