### PR TITLE
fix(bulk): adding tools back to global nav on page filters

### DIFF
--- a/src/connectors/global-nav/global-nav.js
+++ b/src/connectors/global-nav/global-nav.js
@@ -56,7 +56,8 @@ const GlobalNav = (props) => {
   const { t } = useTranslation()
   const dispatch = useDispatch()
   const router = useRouter()
-  const selectedLink = selected !== undefined ? selected : getTopLevelPath(router?.pathname)
+  const topLevelPath = getTopLevelPath(router?.pathname)
+  const selectedLink = selected !== undefined ? selected : topLevelPath
 
   const appMode = useSelector((state) => state?.app?.mode)
   const flagsReady = useSelector((state) => state.features.flagsReady)
@@ -172,7 +173,7 @@ const GlobalNav = (props) => {
   /**
    * Tools are what we use on Saves
    */
-  const showNav = selectedLink === 'saves' && isLoggedIn
+  const showNav = topLevelPath === 'saves' && isLoggedIn
   const tools = showNav
     ? [
         {


### PR DESCRIPTION
## Goal

Tools (search/bulk/add) were missing from the page filters. I believe this happened during the sidebar work

## To Do:

- [x] Show tools on all page filters

## Implementation Decisions

We were relying on the top level path before, now we're doing it again but being a little more explicit.