### PR TITLE
fix(lists): update title on settings update with decoded

### DIFF
--- a/src/connectors/lists/mutation-update.state.js
+++ b/src/connectors/lists/mutation-update.state.js
@@ -132,7 +132,7 @@ function* listUpdate({ id }) {
     const response = yield call(updateShareableList, data)
     yield put({ type: LIST_UPDATE_SUCCESS, title, externalId: id })
 
-    const itemsById = { [id]: { ...response } }
+    const itemsById = { [id]: { ...response, ...data } }
     yield put({ type: LIST_ITEMS_SUCCESS, itemsById })
   } catch (error) {
     yield put({ type: LIST_UPDATE_FAILURE, error })


### PR DESCRIPTION
## Goal

Bug fix. Editing a list with restricted characters results in decoded displaying

## To Do:

- [x] Use decoded and trimmed values after update

## Implementation Decisions

![dance](https://github.com/Pocket/web-client/assets/1273879/e78cf344-cbe4-439f-83ce-cd162805842e)
