### PR TITLE
fix(list-note): update note edit id to be confirm

### DIFF
--- a/src/connectors/confirm/list-item-note-edit.js
+++ b/src/connectors/confirm/list-item-note-edit.js
@@ -30,7 +30,7 @@ export const EditListItemNote = () => {
 
   const handleSubmit = (note) => {
     dispatch(mutateListItemNoteConfirm(note))
-    dispatch(sendSnowplowEvent('shareable-list.item.note.edit.submit', { ...analyticsData, note }))
+    dispatch(sendSnowplowEvent('shareable-list.item.note.edit.confirm', { ...analyticsData, note }))
   }
 
   return showModal ? (

--- a/src/connectors/snowplow/actions/shareable-lists.js
+++ b/src/connectors/snowplow/actions/shareable-lists.js
@@ -656,7 +656,7 @@ export const shareableListActions = {
     ],
     description: 'Fired when a creator cancels out of the Edit Note modal'
   },
-  'shareable-list.item.note.edit.submit': {
+  'shareable-list.item.note.edit.confirm': {
     eventType: 'engagement',
     entityTypes: ['ui', 'shareableListItem'],
     eventData: {


### PR DESCRIPTION
## Goal

Mismatch of snowplow identifiers from the docs vs the build.

## To Do:

- [x] Update note editing id to be `confirm` instead of `submit`

## Implementation Decisions

![lemons](https://github.com/Pocket/web-client/assets/1273879/1bed17b1-df5a-4bb4-ae25-3cd7d78de026)
