### PR TITLE
fix(lists): hide global nav when in reorder [OSL-512]

### DIFF
--- a/src/components/global-nav/global-nav.js
+++ b/src/components/global-nav/global-nav.js
@@ -61,6 +61,10 @@ const headerStyle = css`
     display: none;
   }
 
+  .noNav.logo {
+    margin-left: -4px;
+  }
+
   ${breakpointSmallTablet} {
     .pocket-logo {
       &:hover {

--- a/src/connectors/global-nav/global-nav.js
+++ b/src/connectors/global-nav/global-nav.js
@@ -217,6 +217,7 @@ const GlobalNav = (props) => {
   }
 
   const NavTakeover = navChildren[appMode]
+  const hideNav = noNav || appMode === 'reorder'
 
   const onLoginClick = (event) => {
     event.preventDefault()
@@ -250,7 +251,7 @@ const GlobalNav = (props) => {
       setDetailMode={setDetailMode}
       sendImpression={sendImpressionEvent}
       tools={tools}
-      noNav={noNav}
+      noNav={hideNav}
       flagsReady={flagsReady}>
       {NavTakeover ? <NavTakeover onClose={resetNav} /> : null}
     </GlobalNavComponent>


### PR DESCRIPTION
## Goal

Hide global nav when in reorder mode

## To Do:

- [x] Hide global nav options when in reorder

## Implementation Decisions

Making use of the existing `noNav` prop