### PR TITLE
fix(list): updating item cards so layout is correct with note [OSL-522]

### DIFF
--- a/src/components/item/item-styles.js
+++ b/src/components/item/item-styles.js
@@ -1,6 +1,7 @@
 import { css } from 'linaria'
 import { breakpointLargeHandset } from 'common/constants'
 import { breakpointSmallTablet } from 'common/constants'
+import { breakpointTinyTablet } from 'common/constants'
 import { breakpointMediumHandset } from 'common/constants'
 
 export const itemStyles = css`
@@ -461,6 +462,20 @@ export const itemStyles = css`
       }
       .footer {
         grid-column: span 2;
+      }
+    }
+  }
+
+  &.list-item {
+    footer {
+      grid-column-start: 2;
+    }
+
+    ${breakpointTinyTablet} {
+      .media-block,
+      .item-links,
+      footer {
+        grid-column: span 12;
       }
     }
   }

--- a/src/components/item/item.js
+++ b/src/components/item/item.js
@@ -149,7 +149,7 @@ export const Item = (props) => {
           openUrl={openUrl}
         />
       </span>
-      <div>
+      <div className="item-links">
         <Link
           href={openUrl}
           onClick={onOpen}

--- a/src/connectors/lists/individual-list.card.js
+++ b/src/connectors/lists/individual-list.card.js
@@ -51,6 +51,7 @@ export const IndividualListCard = ({ id, listId, position }) => {
   return (
     <div className={cx(stackedGrid, stackedGridNoAside)}>
       <Item
+        type="list-item"
         listId={listId}
         itemId={externalId}
         title={title}

--- a/src/connectors/lists/public-list.card.js
+++ b/src/connectors/lists/public-list.card.js
@@ -46,6 +46,7 @@ export const PublicListCard = ({ listId, externalId, position }) => {
   return (
     <div className={cx(stackedGrid, stackedGridNoAside)}>
       <Item
+        type="list-item"
         listId={listId}
         itemId={externalId}
         title={title}


### PR DESCRIPTION
## Goal

Images were disappearing on mobile and the card footer was getting squished when adding a note

## To Do:

- [x] Add list specific classname to card
- [x] Add list specific styles for this card type
- [x] Apply to both individual card and public card

## Implementation Decisions

I'm sure there's a better way to use the existing variables here, but I'm unfamiliar with it. This just gets us unblocked.