### PR TITLE
fix(note): display user submitted note on save [OSL-529]

### DIFF
--- a/src/connectors/lists/mutation-update.state.js
+++ b/src/connectors/lists/mutation-update.state.js
@@ -183,7 +183,7 @@ function* listItemAddNote({ id, edit }) {
     const action = edit ? LIST_ITEM_EDIT_NOTE_SUCCESS : LIST_ITEM_ADD_NOTE_SUCCESS
     yield put({ type: action })
 
-    const itemsById = { [id]: { ...response } }
+    const itemsById = { [id]: { ...response, note } }
     yield put({ type: LIST_ITEMS_SUCCESS, itemsById })
   } catch (error) {
     const action = edit ? LIST_ITEM_EDIT_NOTE_FAILURE : LIST_ITEM_ADD_NOTE_FAILURE


### PR DESCRIPTION
## Goal

Display the user submitted note instead of the one returned from the server on save (to prevent string replacement characters from appearing)

## To Do:

- [x] Pass through user submitted note

## Implementation Decisions

This is also how we handle the title and the description