### PR TITLE
fix(item): align tag count variable

### DIFF
--- a/src/components/item/item.js
+++ b/src/components/item/item.js
@@ -221,7 +221,7 @@ export const Item = (props) => {
                 className={cx('card-tags', tagsShown && 'show-tags')}
                 data-cy="card-tags"
                 onMouseEnter={showTags}>
-                {t('item:tag-count', '{{count}} tags', { count: tagCount })}
+                {t('item:tag-count', '{{tagCount}} tag', { tagCount: tagCount })}
                 <ItemTags className="itemTags" tags={tags} mouseLeave={hideTags} />
               </div>
             ) : null}


### PR DESCRIPTION
## Goal

Just moving this back to the original translation variable until the translations come back.

## To Do:

- [x] count -> tagCount

## Implementation Decisions

Looks like we are gonna be switching this during the next version of our localizations.  So this will get reverted soon, but until then this will fix all the things.