### PR TITLE
build(stories) update annotations popover

### DIFF
--- a/src/components/popover/popover-selection.story.js
+++ b/src/components/popover/popover-selection.story.js
@@ -1,11 +1,12 @@
 import { SelectionPopover } from './popover-selection'
 import { useState } from 'react'
+import { css } from '@emotion/css'
 
 export default {
-  title: 'Article/Annotation Selection'
+  title: 'Article/Annotations'
 }
 
-export const Normal = () => {
+export const Selection = () => {
   const [highlight, setHighlight] = useState(null)
 
   const toggleHighlight = () => {
@@ -24,9 +25,17 @@ export const Normal = () => {
 
   return (
     <div onMouseUp={toggleHighlight}>
-      {highlight ? (
-        <SelectionPopover anchor={highlight} disablePopup={clearSelection} />
-      ) : null}
+      <div className={contentStyle}>
+        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Architecto cumque necessitatibus
+        minus, commodi laudantium pariatur nesciunt veniam, animi et, dolore explicabo quis! Eveniet
+        porro deleniti id, laboriosam ipsam maiores temporibus?
+      </div>
+      {highlight ? <SelectionPopover anchor={highlight} disablePopup={clearSelection} /> : null}
     </div>
   )
 }
+
+const contentStyle = css`
+  margin-top: 6rem;
+  max-width: 400px;
+`


### PR DESCRIPTION
## Goal

Surprisingly enough this is meant to `update annotations popover` story.  As it stands now there was nothing to highlight, rendering the story 🍓 😢  

## To Do:

- [x] Fix annotations popover story

## Implementation Decisions

SUPP _working title_ 

![713be9f0079e1dc2](https://github.com/Pocket/web-client/assets/16119672/8e88bc5b-759d-4f7b-8e4c-5ef4a61ddabc)
