### PR TITLE
chore(localization): switch to standard es-LA

### DIFF
--- a/.scripts/localization/locale-inject.js
+++ b/.scripts/localization/locale-inject.js
@@ -10,7 +10,6 @@ function inferInternationalizedLang() {
     'de-DE': ['de', 'de-DE'],
     'es-ES': ['es', 'es-ES'],
     'es-LA': ['es-LA'],
-    'es-XL': ['es-XL'],
     'fr-FR': ['fr', 'fr-FR'],
     'fr-CA': ['fr-CA'],
     'it-IT': ['it', 'it-IT'],

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -10,7 +10,6 @@ module.exports = {
       'es',
       'es-ES',
       'es-LA',
-      'es-XL',
       'fr',
       'fr-CA',
       'fr-FR',

--- a/src/connectors/languages/languages.js
+++ b/src/connectors/languages/languages.js
@@ -17,7 +17,7 @@ const LANGUAGE_BY_LOCALE = {
   'pt-BR': 'Portuguese (Brazil)',
   ru: 'Russian',
   es: 'Spanish (Spain)',
-  'es-XL': 'Spanish (Latin America)'
+  'es-LA': 'Spanish (Latin America)'
 }
 
 export function Languages() {


### PR DESCRIPTION
## Goal
Remove es-xl in favor of es-la

## To Do:

- [x] Remove `es-XL` from injection
- [x] Remove `es-XL` from next-i18next config
- [x] Switch language selector to `es-LA` for Latin America

## Implementation Decisions

We have legacy support for `es-XL` which is a relic that is no longer supported. This just switches to standard `es-LA` for latin America.  That is what comes from Smartling so this will get us back in sync
