### PR TITLE
fix(sidebar): update list sidebar on list note change and reorder

### DIFF
--- a/src/containers/lists/lists.state.js
+++ b/src/containers/lists/lists.state.js
@@ -31,6 +31,10 @@ import { LIST_RECENT_FAILURE } from 'actions'
 import { LIST_ADD_ITEM_SUCCESS } from 'actions'
 import { LIST_DELETE_ITEM_SUCCESS } from 'actions'
 import { LIST_UPDATE_STATUS_SUCCESS } from 'actions'
+import { LIST_ITEM_ADD_NOTE_SUCCESS } from 'actions'
+import { LIST_ITEM_EDIT_NOTE_SUCCESS } from 'actions'
+import { LIST_ITEM_NOTE_DELETE_SUCCESS } from 'actions'
+import { LIST_ITEMS_REORDER_SUCCESS } from 'actions'
 
 import { VARIANTS_SAVE } from 'actions'
 
@@ -98,7 +102,11 @@ export const pageListsInfoSagas = [
       LIST_UPDATE_SUCCESS,
       LIST_UPDATE_STATUS_SUCCESS,
       LIST_ADD_ITEM_SUCCESS,
-      LIST_DELETE_ITEM_SUCCESS
+      LIST_DELETE_ITEM_SUCCESS,
+      LIST_ITEM_ADD_NOTE_SUCCESS,
+      LIST_ITEM_EDIT_NOTE_SUCCESS,
+      LIST_ITEM_NOTE_DELETE_SUCCESS,
+      LIST_ITEMS_REORDER_SUCCESS
     ],
     getRecentLists
   )


### PR DESCRIPTION
## Goal

We'll want to make sure the sidebar is up to date when a user updates a list item note or reorders a list

## To Do:

- [x] Add, edit, or delete a note
- [x] Reorder a list

## Implementation Decisions

There will be no visual change until the backend team finishes their work here:
https://getpocket.atlassian.net/browse/OSL-532

I had already implemented the two chunks of data, this was to get the last chunk based on Jonathan's confirmation.