### PR TITLE
fix(call out): newsroom callout links to a new tab

### DIFF
--- a/src/components/call-out/newsroom.tsx
+++ b/src/components/call-out/newsroom.tsx
@@ -92,13 +92,17 @@ export function CallOutNewsroom() {
         <ol>
           <li>
             Find your local newsroom using{' '}
-            <a href="https://findyournews.org/campaign/inn-network-directory">this&nbsp;database</a>
+            <a href="https://findyournews.org/campaign/inn-network-directory" target="_blank">
+              this&nbsp;database
+            </a>
           </li>
           <li>If they have a newsletter, subscribe and share it with friends</li>
           <li>Support your local news organization with a recurring donation</li>
           <li>
             Learn more about the
-            <a href="https://www.theajp.org/why-local-news/"> state of local news</a>
+            <a href="https://www.theajp.org/why-local-news/" target="_blank">
+              state of local news
+            </a>
           </li>
           <li>Save local stories in Pocket to read whenever, wherever</li>
         </ol>


### PR DESCRIPTION
## Goal

Request to open links from the newsroom callouts in a new tab

## To Do:

- [x] add `target=_blank`

## Implementation Decisions
![smol](https://github.com/Pocket/web-client/assets/16119672/cdec3d0b-56ff-4511-9ae6-b4b5632fb982)
