### PR TITLE
fix(lists): fetch list item count with recent list request [OSL-560]

### DIFF
--- a/src/common/api/queries/get-shareable-lists-recent.js
+++ b/src/common/api/queries/get-shareable-lists-recent.js
@@ -7,6 +7,10 @@ const getRecentShareableListsQuery = gql`
     shareableLists {
       title
       externalId
+      listItems {
+        externalId
+        itemId: externalId
+      }
     }
   }
 `

--- a/src/containers/lists/lists.state.js
+++ b/src/containers/lists/lists.state.js
@@ -7,6 +7,7 @@ import { getShareableListPublic } from 'common/api/queries/get-shareable-list-pu
 import { getRecentShareableLists } from 'common/api/queries/get-shareable-lists-recent'
 
 import { decodeSpecialChars } from 'common/api/derivers/shared-lists'
+import { arrayToObject } from 'common/utilities/object-array/object-array'
 
 import { LIST_ITEMS_SUCCESS } from 'actions'
 
@@ -168,12 +169,19 @@ function* getRecentLists() {
   try {
     const shareableLists = yield getRecentShareableLists()
     const listsIds = shareableLists.map((list) => list.externalId)
+    const lists = shareableLists.map(({ listItems, ...rest }) => ({
+      listItemIds: listItems.map(({ itemId }) => itemId),
+      ...rest
+    }))
+    const itemsById = arrayToObject(lists, 'externalId')
+
     const titleToIdList = shareableLists.reduce(
       (obj, list) => ({ ...obj, [decodeSpecialChars(list.title)]: list.externalId }),
       {}
     )
 
     yield put({ type: LIST_RECENT_SUCCESS, listsIds, titleToIdList })
+    yield put({ type: LIST_ITEMS_SUCCESS, itemsById })
   } catch {
     yield put({ type: LIST_RECENT_FAILURE })
   }


### PR DESCRIPTION
## Goal

We need list item count in order to add to a list

## To Do:

- [x] Update recent request to include list item ids
- [x] Parse list item ids and add to listsDisplay

## Implementation Decisions

Using the info from Joseph and Aly to locate the bug!