### PR TITLE
fix(collections): load cat/sub cat correctly

### DIFF
--- a/src/containers/collections/stories-page/stories-page.js
+++ b/src/containers/collections/stories-page/stories-page.js
@@ -87,8 +87,8 @@ export function CollectionPage({ locale, queryParams = {}, slug, statusCode }) {
   const { asPath: urlPath } = router
   const targeting = {
     URL: urlPath,
-    Category: IABParentCategory,
-    SubCategory: IABChildCategory,
+    Category: IABParentCategory?.slug,
+    SubCategory: IABChildCategory?.slug,
     ArticleID: externalId
   }
 


### PR DESCRIPTION
## Goal

Collections wasn't picking up GA as expected.  This adjusts the cat/sub-cat to pull the vars out of the passed object.

## To Do:

- [x] Pass slug instead of object.

