### PR TITLE
fix(banner): newsroom only in us

### DIFF
--- a/src/containers/saves/saves.js
+++ b/src/containers/saves/saves.js
@@ -64,8 +64,10 @@ export const Saves = (props) => {
   }
 
   // Campaign
+  const { locale = 'en' } = router
+  const isEnglish = ['en', 'en-US'].includes(locale)
   const showNewsroomCampaign = featureFlagActive({ flag: 'newsroom', featureState })
-  const bannerCampaign = showNewsroomCampaign ? 'newsroom' : false
+  const bannerCampaign = showNewsroomCampaign && isEnglish ? 'newsroom' : false
 
   return (
     <Layout


### PR DESCRIPTION
## Goal

Limit saves page newsroom banner to US only

## To Do:

- [x] Get locale from router
- [x] Add condition to banner on saves
