### PR TITLE
fix(collections): add new article to newsroom urls

### DIFF
--- a/src/containers/collections/stories-page/stories-page.js
+++ b/src/containers/collections/stories-page/stories-page.js
@@ -54,7 +54,8 @@ const newsroomUrls = [
   'https://getpocket.com/collections/the-american-journalism-project',
   'https://getpocket.com/collections/ajp-systemic-injustice',
   'https://getpocket.com/collections/ajp-lgbtq-legislation',
-  'https://getpocket.com/collections/ajp-community-heroes'
+  'https://getpocket.com/collections/ajp-community-heroes',
+  'https://getpocket.com/collections/ajp-challenging-the-status-quo'
 ]
 
 export function CollectionPage({ locale, queryParams = {}, slug, statusCode }) {


### PR DESCRIPTION
## Goal

Add new article to newsroom urls

## To Do:

- [x] add new article to newsroom urls (collections/ajp-challenging-the-status-quo)

## Implementation Decisions

![Screenshot 2023-07-24 at 3 14 44 PM](https://github.com/Pocket/web-client/assets/16119672/59ab1448-7de3-46b8-ad42-50b37c5d5d25)
