### PR TITLE
fix(api): redirect user to login page when requesting items and not logged in

### DIFF
--- a/src/common/api/queries/get-saved-items.js
+++ b/src/common/api/queries/get-saved-items.js
@@ -4,6 +4,8 @@ import { FRAGMENT_ITEM } from 'common/api/fragments/fragment.item'
 import { itemFiltersFromGraph } from './get-saved-items.filters'
 import { actionToCamelCase } from 'common/utilities/strings/strings'
 
+import { LOGIN_URL } from 'common/constants'
+
 const getSavedItemsQuery = gql`
   query GetSavedItems(
     $filter: SavedItemsFilter
@@ -61,6 +63,11 @@ export async function getSavedItems({ actionType, sortOrder = 'DESC', tagNames, 
 function handleResponse(response) {
   const responseData = response?.data?.user?.savedItems
 
+  if (response?.errors && response?.errors?.[0]?.extensions?.status === 401) {
+    window.location = `${LOGIN_URL}?src=web-client`
+    throw new UnauthenticatedItemRequestError()
+  }
+
   if (!responseData) throw new Error(response?.errors)
 
   const { pageInfo, edges, totalCount } = responseData
@@ -71,5 +78,12 @@ class MalformedItemRequestError extends Error {
   constructor(message) {
     super(message)
     this.name = 'MalformedItemRequestError'
+  }
+}
+
+class UnauthenticatedItemRequestError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'UnauthenticatedItemRequestError'
   }
 }


### PR DESCRIPTION
## Goal

Auth status was only being checked on initial application load, not during sessions. This led to states where a user could be logged out, but still within the application which would result in a blank list.

## To Do:

- [x] Check for auth status on items request and redirect to login page
- [x] Throw custom sentry error in case we ever want to dig into these instances

## Implementation Decisions

*_How to test_*
1. Run the branch locally
2. View Saves
3. Open new tab and navigate to `getpocket.com/lo` (this will log you out of the application)
4. Switch back to the original tab
5. Be redirected to login

_or_

1. Run the branch locally
2. View Discover
3. Open new tab and navigate to `getpocket.com/lo` (this will log you out of the application)
4. Switch back to the original tab
5. Click Home in the Global Nav
6. Be redirected to login