### PR TITLE
fix(flag): limit for those in fxa (not lab)

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -50,7 +50,7 @@ function PocketWebClient({ Component, pageProps, err }) {
   const { flagsReady } = useSelector((state) => state.features)
   const { authRequired } = pageProps
 
-  const fxaFlag = featureFlagActive({ flag: 'lab', featureState })
+  const fxaFlag = featureFlagActive({ flag: 'fxa', featureState })
   const forceFxaRedirect = featureFlagActive({ flag: 'forceFxaRedirect', featureState })
   const restrictedLink = authRequired && location !== '/learn-more' && (!isFXA || forceFxaRedirect)
 


### PR DESCRIPTION
## Goal

Switch flag to `fxa` from `lab`

## To Do:

- [x] Flag name that is ready for production switching

## Implementation Decisions

![giphy-6](https://github.com/Pocket/web-client/assets/16119672/20bd0fc4-ee7e-4a7a-9ceb-99b3b88f6673)

