### PR TITLE
fix(saves): throw custom error on saves request fail

### DIFF
--- a/src/connectors/items/items-saved.state.js
+++ b/src/connectors/items/items-saved.state.js
@@ -112,6 +112,7 @@ function* savedItemRequest(action) {
     yield put({ type: ITEMS_SAVED_SUCCESS, nodes, savedItemIds })
   } catch (errors) {
     yield put({ type: ITEMS_SAVED_FAILURE, errors })
+    Sentry.captureException(new SavedItemsError(errors))
   }
 }
 
@@ -138,6 +139,7 @@ function* savedItemTaggedRequest(action) {
     yield put({ type: ITEMS_SAVED_SUCCESS, nodes, savedItemIds })
   } catch (errors) {
     yield put({ type: ITEMS_SAVED_TAGGED_FAILURE, errors })
+    Sentry.captureException(new SavedItemsTaggedError(errors))
   }
 }
 
@@ -214,7 +216,7 @@ const getNodeFromEdge = (previous, current) => {
   const cursor = current.cursor
   const { item, ...node } = current.node
   if (node.status === 'DELETED') return previous // REMOVE DELETED ITEMS FROM THE RESPONSE
-  return { ...previous, [node.id]: { cursor, ...node }}
+  return { ...previous, [node.id]: { cursor, ...node } }
 }
 
 const getItemFromEdge = (previous, current) => {
@@ -233,4 +235,24 @@ const getSearchItemFromEdge = (previous, current) => {
   const { item, node } = deriveSavedItem(current.node.savedItem)
   if (node.status === 'DELETED') return previous
   return { ...previous, [node.id]: item } // REMOVE DELETED ITEMS FROM THE RESPONSE
+}
+
+/**
+ * Errors 
+ ----------------------------------------------------------------------------*/
+
+class SavedItemsError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'SavedItemsError'
+    this.logMessage = message
+  }
+}
+
+class SavedItemsTaggedError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'SavedItemsTaggedError'
+    this.logMessage = message
+  }
 }


### PR DESCRIPTION
## Goal

Throwing a custom error to better track down saves not firing for all users.  This is generally coming from a server error, but may be caused by how we are requesting, or the account getting out of sync somehow.

## To Do:

- [x] Add custom errors to Sentry on item request failures

## Implementation Decisions

Sentry is a mess ... this is a superficial pass at getting some signal without taking too deep of a dive.