### PR TITLE
fix(syndicated): syndicated articles to noindex [SOC-107]

### DIFF
--- a/src/containers/_layouts/_head.js
+++ b/src/containers/_layouts/_head.js
@@ -2,7 +2,7 @@ import Head from 'next/head'
 import { getImageCacheUrl } from 'common/utilities/urls/urls'
 import { FACEBOOK_APP_ID } from 'common/constants'
 
-export const PocketHead = ({ metaData = {}, title: pageTitle, canonical, forceWebView }) => {
+export const PocketHead = ({ metaData = {}, title: pageTitle, canonical, noIndex, forceWebView }) => {
   const { url = '', description = '', title = '', type = 'website', image } = metaData
 
   const twitterCardType = image ? 'summary_large_image' : 'summary'
@@ -17,6 +17,7 @@ export const PocketHead = ({ metaData = {}, title: pageTitle, canonical, forceWe
       <title>{pageTitle}</title>
 
       {canonical ? <link rel="canonical" href={canonical} /> : null}
+      {noIndex ? <meta name="robots" content="noindex" /> : null}
 
       {forceWebView ? <meta name="x-pocket-force-webview"/> : null}
       {/*  Primary Meta Tags */}

--- a/src/containers/_layouts/fxa.tsx
+++ b/src/containers/_layouts/fxa.tsx
@@ -28,7 +28,7 @@ function mainLayout({
 }) {
   return (
     <>
-      <PocketHead title={title} canonical={canonical} metaData={metaData} forceWebView={true} />
+      <PocketHead title={title} canonical={canonical} metaData={metaData} forceWebView={true} noIndex={false}/>
       <GlobalNav onlyLogout={true} />
       <div className={cx(fixedNavContainer)}>{children}</div>
     </>

--- a/src/containers/syndicated-article/syndicated-article.js
+++ b/src/containers/syndicated-article/syndicated-article.js
@@ -96,7 +96,8 @@ export function SyndicatedArticle({ queryParams = validParams, locale }) {
     image: mainImage,
     type: 'article'
   }
-  const canonical = publisher?.attributeCanonicalToPublisher ? publisherUrl : url
+  const canonical = publisher?.attributeCanonicalToPublisher ? false : url
+  const noIndex = publisher?.attributeCanonicalToPublisher
 
   const ArticleLayout = isMobileWebView ? MobileLayout : Layout
 
@@ -148,6 +149,7 @@ export function SyndicatedArticle({ queryParams = validParams, locale }) {
         title={title}
         metaData={articleMetaData}
         canonical={canonical}
+        noIndex={noIndex}
         className={printLayout}>
         <main className={contentLayout}>
           <section>


### PR DESCRIPTION
## Goal

We no longer want to set canonical links on syndicated articles, we would rather just noIndex them (don't show up in search) via request from SEO

## To Do:

- [x] set canonical to false if `attributeCanonicalToPublisher` is sent down
- [x] set noIndex if `attributeCanonicalToPublisher` is sent down

## Implementation Decisions

🍋 🪗 