### PR TITLE
fix(learn-more): Remove "Firefox account" language from Learn More [SOCIALPLAT-501]

### DIFF
--- a/public/locales/en/learn-more.json
+++ b/public/locales/en/learn-more.json
@@ -3,7 +3,9 @@
   "cancel-button": "Cancel Premium",
   "cancel-header": "Cancel Premium subscription",
   "condition-benefits": "Benefits of a Firefox account, powered by Mozilla, include better account security",
+  "condition-benefits-rebrand": "Benefits include better account security",
   "condition-pocket-access": "If you do not update to a Firefox account, you cannot access Pocket",
+  "condition-pocket-access-rebrand": "If you do not update, you cannot access Pocket",
   "condition-usage": "You will still be able to use any browser, our iOS or Android apps to access Pocket",
   "delete-body": "Permanently delete your Pocket account. This will delete your account and all items within it.",
   "delete-button": "Delete account",
@@ -18,5 +20,6 @@
   "no-update-options": "Here are your other options:",
   "title": "Learn more about Firefox migration",
   "update-button": "Update account",
-  "update-header": "Update your Pocket login to a Firefox&nbsp;account"
+  "update-header": "Update your Pocket login to a Firefox&nbsp;account",
+  "update-header-rebrand": "Update your Pocket login"
 }

--- a/src/containers/learn-more/learn-more.tsx
+++ b/src/containers/learn-more/learn-more.tsx
@@ -9,6 +9,7 @@ import { AccountClearModal } from 'containers/account/privacy/confirm-clear'
 import { accountDelete } from 'containers/account/privacy/privacy.state'
 import { breakpointLargeHandset } from 'common/constants'
 import { setCookie } from 'nookies'
+import { featureFlagActive } from 'connectors/feature-flags/feature-flags'
 import { sendSnowplowEvent } from 'connectors/snowplow/snowplow.state'
 
 const leanMoreStyles = css`
@@ -108,6 +109,10 @@ export default function LearnMore() {
   const { t } = useTranslation()
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const featureState = useSelector((state: any) => state.features)
+  const enrolledRebranding = featureFlagActive({ flag: 'fxa.rebranding', featureState })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const isPremium = useSelector((state: any) => state.user.premium_status === '1')
 
   const handleUpgrade = () => {
@@ -135,9 +140,13 @@ export default function LearnMore() {
           <PageContainer>
             <LogoMark className="logo" />
             <h1>
-              <Trans i18nKey="learn-more:update-header">
-                Update your Pocket login to a Firefox&nbsp;account
-              </Trans>
+              {enrolledRebranding ? (
+                <Trans i18nKey="learn-more:update-header-rebrand">Update your Pocket login</Trans>
+              ) : (
+                <Trans i18nKey="learn-more:update-header">
+                  Update your Pocket login to a Firefox&nbsp;account
+                </Trans>
+              )}
             </h1>
             <ul>
               <li>
@@ -147,16 +156,26 @@ export default function LearnMore() {
                 )}
               </li>
               <li>
-                {t(
-                  'learn-more:condition-benefits',
-                  'Benefits of a Firefox account, powered by Mozilla, include better account security'
-                )}
+                {enrolledRebranding
+                  ? t(
+                      'learn-more:condition-benefit-rebrand',
+                      'Benefits include better account security'
+                    )
+                  : t(
+                      'learn-more:condition-benefits',
+                      'Benefits of a Firefox account, powered by Mozilla, include better account security'
+                    )}
               </li>
               <li>
-                {t(
-                  'learn-more:condition-pocket-access',
-                  'If you do not update to a Firefox account, you cannot access Pocket'
-                )}
+                {enrolledRebranding
+                  ? t(
+                      'learn-more:condition-pocket-access-rebrand',
+                      'If you do not update, you cannot access Pocket'
+                    )
+                  : t(
+                      'learn-more:condition-pocket-access',
+                      'If you do not update to a Firefox account, you cannot access Pocket'
+                    )}
               </li>
             </ul>
             <button className="large" onClick={handleUpgrade}>


### PR DESCRIPTION
## Goal

Remove "Firefox account" language from Learn More - [SOCIALPLAT-501](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-501)

## To Do:

- [x] Change main heading to “Update your Pocket login”
- [x] Change second bullet to “Benefits include better account security” 
- [x] Change last bullet to “If you do not update, you cannot access Pocket”


New version
<img width="975" alt="image" src="https://github.com/Pocket/web-client/assets/14023085/5e5962ab-cf87-49a9-b4cd-0774612bae8b">


Original for reference / picture of local with flag off
<img width="931" alt="image" src="https://github.com/Pocket/web-client/assets/14023085/ba0ae0ed-0720-4559-81fb-006cf852def8">



[SOCIALPLAT-501]: https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ