### PR TITLE
fix(lists): hide list status toggle when set to private [POCKET-9215]

### DIFF
--- a/src/components/headers/lists-header.js
+++ b/src/components/headers/lists-header.js
@@ -223,6 +223,7 @@ export const ListIndividualHeader = ({
   const { t } = useTranslation()
 
   const enrolledInternal = enrolledDev || enrolledPilot
+  const isPublic = status !== 'PRIVATE'
 
   const publicListInfo = {
     externalId,
@@ -246,7 +247,7 @@ export const ListIndividualHeader = ({
 
       <div className="list-actions">
         <div className="actions-start">
-          {enrolledInternal ? (
+          {enrolledInternal && isPublic ? (
             <VisibilityOptions
               status={status}
               listItemNoteVisibility={listItemNoteVisibility}


### PR DESCRIPTION
## Goal

Hide list status toggle when a list is set to private

## To Do:

- [x] Check list status
- [x] Only show list status if not private

## Implementation Decisions

This implementation leaves the toggle if the list is set to public, this way a user can still hide it if they'd like. They will _not_ be able to set it to public again.

<img width="622" alt="image" src="https://github.com/Pocket/web-client/assets/1273879/6eecacc2-132e-4c98-97e8-070b09db4d57">
