### PR TITLE
fix(listen): send braze event on signup action

### DIFF
--- a/src/connectors/listen/listen-login.js
+++ b/src/connectors/listen/listen-login.js
@@ -54,7 +54,12 @@ export const ListenLogin = ({ itemId, path }) => {
 
   const showListen = listenLab || listenEnrolled
 
-  const signUpEvent = () => dispatch(sendSnowplowEvent('listen.signup'))
+  const signUpEvent = () => {
+    import('common/utilities/braze/braze-lazy-load').then(({ logCustomEvent }) =>
+      logCustomEvent('listen.signup', analyticsData)
+    )
+    dispatch(sendSnowplowEvent('listen.signup'))
+  }
 
   const loggedIn = userStatus === 'valid'
   const ElementToRender = loggedIn ? Listen : LoggedOut


### PR DESCRIPTION
## Goal

Let's add one more Braze event who click the "Sign Up" button on the Listen module. This demonstrates a clear connection between listen and signup interest

## To Do:

- [x] Add Braze event to signup action

## Implementation Decisions

This seems like it could be a good action to use for triggering surveys and such