### PR TITLE
fix(listen): add braze event to signup action

### DIFF
--- a/src/components/share-modal/share-mastodon.js
+++ b/src/components/share-modal/share-mastodon.js
@@ -1,0 +1,44 @@
+import { css } from '@emotion/css'
+import { useState } from 'react'
+import { useTranslation } from 'next-i18next'
+
+import { Modal, ModalBody, ModalTabs } from 'components/modal/modal'
+
+import { Card } from 'components/item-card/card'
+import { SelectShareType } from './share-selector'
+import { ShareList } from './share-list'
+import { ShareRecommend } from './share-recommend'
+
+const shareQuote = css`
+  margin: var(--spacing050) 0;
+  padding: 0 var(--spacing100);
+  border-left: 1px solid var(--color-dividerSecondary);
+  color: var(--color-textSecondary);
+  font-style: italic;
+  font-size: var(--fontSize085);
+`
+
+export const ShareModal = ({
+  title,
+  publisher,
+  excerpt,
+  timeToRead,
+  isSyndicated,
+  externalUrl,
+  thumbnail,
+  quote,
+  showModal,
+  cancelShare,
+  engagementEvent,
+  recommendEvent
+}) => {
+  return (
+    <Modal
+      title="Share to Mastodon"
+      isOpen={showModal}
+      screenReaderLabel="Share to Mastodon"
+      handleClose={cancelShare}>
+      <ModalBody>body body body</ModalBody>
+    </Modal>
+  )
+}

--- a/src/connectors/listen/listen-login.js
+++ b/src/connectors/listen/listen-login.js
@@ -54,7 +54,12 @@ export const ListenLogin = ({ itemId, path }) => {
 
   const showListen = listenLab || listenEnrolled
 
-  const signUpEvent = () => dispatch(sendSnowplowEvent('listen.signup'))
+  const signUpEvent = () => {
+    import('common/utilities/braze/braze-lazy-load').then(({ logCustomEvent }) =>
+      logCustomEvent('listen.signup', analyticsData)
+    )
+    dispatch(sendSnowplowEvent('listen.signup'))
+  }
 
   const loggedIn = userStatus === 'valid'
   const ElementToRender = loggedIn ? Listen : LoggedOut


### PR DESCRIPTION
## Goal

Let's add one more Braze event who click the "Sign Up" button on the Listen module. This demonstrates a clear connection between listen and signup interest

## To Do:

- [x] Add Braze event to signup action

## Implementation Decisions

This seems like it could be a good action to use for triggering surveys and such