### PR TITLE
fix(apollo): update to allow apollo router strictness

### DIFF
--- a/src/common/api/queries/get-saved-items-search.js
+++ b/src/common/api/queries/get-saved-items-search.js
@@ -67,6 +67,9 @@ export async function getSavedItemsSearch({
 
   const { filter, sort } = requestDetails
   const variables = { filter: { ...filter }, sort: { ...sort, sortOrder }, term, pagination }
+  if (Object.keys(variables.filter).length == 0){
+    delete variables.filter;
+  }
   const operationName = actionToCamelCase(actionType)
 
   return requestGQL({ query: searchSavedItemsQuery, operationName, variables })


### PR DESCRIPTION
## Goal

Enable @kschelonka and @bassrock to deploy the Apollo router which is more strict about empty objects

## To Do:

- [x] Test Locally

## Implementation Decisions
Used the easiest way to compare keys I know, happy to change this in followup.

