### PR TITLE
fix(analytics): add custom src and utm_source params to all login links [POCKET-9574]

### DIFF
--- a/src/common/api/queries/get-saved-items.js
+++ b/src/common/api/queries/get-saved-items.js
@@ -65,7 +65,7 @@ function handleResponse(response) {
   const responseData = response?.data?.user?.savedItems
 
   if (response?.errors && response?.errors?.[0]?.extensions?.status === 401) {
-    window.location = `${LOGIN_URL}?src=web-client`
+    window.location = `${LOGIN_URL}?src=web-reauth&utm_source=${window.location.href}`
     throw new UnauthenticatedItemRequestError()
   }
 

--- a/src/components/call-out/call-out-build-home.js
+++ b/src/components/call-out/call-out-build-home.js
@@ -155,7 +155,7 @@ export function CallOutBuildHome({ source = 'explore', topBorder }) {
           className="button brand"
           target="_blank"
           rel="noreferrer"
-          href={`${SIGNUP_URL}?utm_source=${source}&utm_medium=web`}>
+          href={`${SIGNUP_URL}?src=web-add-callout&utm_source=${global.location.href}&utm_medium=web`}>
           {t('call-out:sign-up', 'Sign Up')}
         </a>
       </aside>

--- a/src/components/call-out/call-out-start-library.js
+++ b/src/components/call-out/call-out-start-library.js
@@ -150,7 +150,7 @@ export function CallOutStartLibrary({
             target="_blank"
             rel="noreferrer"
             onClick={handleButtonClick}
-            href={`${SIGNUP_URL}?utm_source=explore&utm_medium=web`}>
+            href={`${SIGNUP_URL}?src=web-library-callout&utm_source=${global.location.href}&utm_medium=web`}>
             {t('discover:start-your-library', 'Start your library')}
           </a>
         </div>

--- a/src/components/global-nav/account/global-nav-account.js
+++ b/src/components/global-nav/account/global-nav-account.js
@@ -5,6 +5,7 @@ import { css, cx } from '@emotion/css'
 import { Trans, useTranslation } from 'next-i18next'
 import { useCorrectEffect } from 'common/utilities/hooks/use-correct-effect'
 import { KEYS, PREMIUM_URL } from 'common/constants'
+import { SIGNUP_URL, LOGIN_URL } from 'common/constants'
 import { NewViewIcon } from 'components/icons/NewViewIcon'
 import { breakpointLargeHandset } from 'common/constants'
 import { ProfileIcon } from 'components/icons/ProfileIcon'
@@ -204,7 +205,6 @@ const GlobalNavAccount = ({
   const handleViewProfileCase = () => onLinkClick('view-profile')
   const handleManageAccountCase = () => onLinkClick('manage-account')
   const handleHelpCase = () => onLinkClick('help')
-  const handleMessagesCase = () => onLinkClick('messages')
   const handleLogoutCase = () => {
     onLinkClick('logout')
     // Fire for all users when Braze launches
@@ -232,7 +232,7 @@ const GlobalNavAccount = ({
   return !isLoggedIn ? (
     <div>
       <a
-        href="https://getpocket.com/login?src=navbar"
+        href={`${LOGIN_URL}?src=web-nav&utm_source=${global.location.href}`}
         id="global-nav-login-link"
         className={`${accountLinkStyle} login-link`}
         onClick={onLoginClick}
@@ -240,7 +240,7 @@ const GlobalNavAccount = ({
         <Trans i18nKey="nav:log-in">Log in</Trans>
       </a>
       <a
-        href="https://getpocket.com/signup?src=navbar"
+        href={`${SIGNUP_URL}?src=web-nav&utm_source=${global.location.href}`}
         id="global-nav-signup-link"
         className={cx(signupLinkStyle, 'button secondary')}
         onClick={handleSignupCase}

--- a/src/components/item-actions/save-to-pocket.js
+++ b/src/components/item-actions/save-to-pocket.js
@@ -87,8 +87,8 @@ const popoverContainer = css`
 `
 
 export const SavePopover = function ({ popoverRef, id }) {
-  const loginUrl = `${LOGIN_URL}?route=${global.location.href}`
-  const signupUrl = `${SIGNUP_URL}?route=${global.location.href}`
+  const loginUrl = `${LOGIN_URL}?src=web-save&utm_source=${global.location.href}&route=${global.location.href}`
+  const signupUrl = `${SIGNUP_URL}?src=web-save&utm_source=${global.location.href}&route=${global.location.href}`
   return (
     //prettier-ignore
     <div className={popoverContainer} ref={popoverRef} data-cy={`article-save-login-popup-${id}`}>

--- a/src/components/item/actions/signaled.js
+++ b/src/components/item/actions/signaled.js
@@ -127,8 +127,8 @@ export function SignaledActions({
 }
 
 export const SavePopover = function ({ popoverRef, id }) {
-  const loginUrl = `${LOGIN_URL}?route=${global.location.href}`
-  const signupUrl = `${SIGNUP_URL}?route=${global.location.href}`
+  const loginUrl = `${LOGIN_URL}?src=web-save&utm_source=${global.location.href}&route=${global.location.href}`
+  const signupUrl = `${SIGNUP_URL}?src=web-save&utm_source=${global.location.href}&route=${global.location.href}`
   return (
     //prettier-ignore
     <div className={popoverContainer} ref={popoverRef} data-cy={`article-save-login-popup-${id}`}>

--- a/src/components/item/actions/transitional.js
+++ b/src/components/item/actions/transitional.js
@@ -69,12 +69,16 @@ export function TransitionalActions({
   return (
     <div className={`${transitionalActionStyles} status-${saveStatus}`}>
       {isSaved ? (
-        <button className="saved" ref={popTrigger} onClick={onUnSave} data-cy='article-save-btn-saved'>
+        <button
+          className="saved"
+          ref={popTrigger}
+          onClick={onUnSave}
+          data-cy="article-save-btn-saved">
           <SaveFilledIcon className="saveIcon" />
           <span className="copy">{t('item-action:save-saved', 'Saved')}</span>
         </button>
       ) : (
-        <button className="save" ref={popTrigger} onClick={onSave} data-cy='article-save-btn-save'>
+        <button className="save" ref={popTrigger} onClick={onSave} data-cy="article-save-btn-save">
           <SaveIcon className="saveIcon" />
           <span className="copy">{t('item-action:save-unsaved', 'Save')}</span>
         </button>
@@ -86,8 +90,8 @@ export function TransitionalActions({
 }
 
 export const SavePopover = function ({ popoverRef, id }) {
-  const loginUrl = `${LOGIN_URL}?route=${global.location.href}`
-  const signupUrl = `${SIGNUP_URL}?route=${global.location.href}`
+  const loginUrl = `${LOGIN_URL}?src=web-save&utm_source=${global.location.href}&route=${global.location.href}`
+  const signupUrl = `${SIGNUP_URL}?src=web-save&utm_source=${global.location.href}&route=${global.location.href}`
   return (
     //prettier-ignore
     <div className={popoverContainer} ref={popoverRef} data-cy={`article-save-login-popup-${id}`}>

--- a/src/connectors/global-nav/global-nav.js
+++ b/src/connectors/global-nav/global-nav.js
@@ -221,7 +221,7 @@ const GlobalNav = (props) => {
   const onLoginClick = (event) => {
     event.preventDefault()
     event.stopPropagation()
-    window.location.assign(`${LOGIN_URL}?src=navbar`)
+    window.location.assign(`${LOGIN_URL}?src=web-nav&utm_source=${global.location.href}`)
   }
 
   const CurrentBanner = bannerCampaign ? Banner : null

--- a/src/connectors/listen/listen-login.js
+++ b/src/connectors/listen/listen-login.js
@@ -72,7 +72,9 @@ export const ListenLogin = ({ itemId, path }) => {
 const LoggedOut = ({ clickEvent, path = '' }) => (
   <p className={loggedOutStyle}>
     <ListenIcon /> Want to Listen to this article?{' '}
-    <a href={`${LOGIN_URL}?route=${path}&utm_campaign=syndicated-listen`} onClick={clickEvent}>
+    <a
+      href={`${LOGIN_URL}?src=web-syndicated-listen&utm_source=${global.location.href}&route=${path}`}
+      onClick={clickEvent}>
       Sign in
     </a>
   </p>

--- a/src/containers/account/privacy/privacy.state.js
+++ b/src/containers/account/privacy/privacy.state.js
@@ -113,7 +113,7 @@ function* accountDeleteProcess() {
   const { status, error } = response
 
   if (status === 1) {
-    document.location.href = LOGIN_URL
+    document.location.href = `${LOGIN_URL}?src=web-delete-success&utm_source=${global.location.href}`
     return yield put({ type: ACCOUNT_DELETE_SUCCESS })
   }
 

--- a/src/containers/account/profile/profile.state.js
+++ b/src/containers/account/profile/profile.state.js
@@ -199,7 +199,7 @@ function* accountUsernameUpdate(action) {
 
   if (status === 1) {
     yield put({ type: ACCOUNT_USERNAME_UPDATE_SUCCESS })
-    document.location.href = LOGIN_URL
+    document.location.href = `${LOGIN_URL}?src=web-username-updated&utm_source=${global.location.href}`
     return
   }
   yield put({ type: ACCOUNT_USERNAME_UPDATE_FAILURE, err: error })
@@ -215,7 +215,7 @@ function* accountPasswordUpdate(action) {
 
   if (status === 1) {
     yield put({ type: ACCOUNT_PASSWORD_UPDATE_SUCCESS })
-    document.location.href = LOGIN_URL
+    document.location.href = `${LOGIN_URL}?src=web-password-updated&utm_source=${global.location.href}`
     return
   }
 

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,5 +1,6 @@
 import '../../public/static/pocket-web-ui.css'
 import { GOOGLE_ANALYTICS_ID } from 'common/constants'
+import { LOGIN_URL } from 'common/constants'
 
 import createCache from '@emotion/cache'
 import { CacheProvider } from '@emotion/react'
@@ -153,7 +154,7 @@ function PocketWebClient({ Component, pageProps, err }) {
 
     // User is not logged in
     if (user_status === 'invalid') {
-      window.location = 'https://getpocket.com/login?src=web-client'
+      window.location = `${LOGIN_URL}?src=web-auth&utm_source=${window.location.href}`
     }
 
     // User is logged in but not via FXA


### PR DESCRIPTION
## Goal

Add custom params to all links leading users to sign in and log in pages

## To Do:

- [x] Log in
- [x] Sign in

## Implementation Decisions

I implemented 2 query params:
1. `src` = Identifies the button
2. `utm_source` = The full url the user came from

Here's what each `src` means:
```
web-auth => landed on an auth required page while logged out
web-reauth => fetched saves and received a 401
web-nav => global nav (every page)
web-save => Any "Save to Pocket" button across all surfaces while logged out
web-syndicated-listen => The Sign Up button on the Listen component on syndicated articles
web-delete-success => Deleted account success
web-username-updated => Username update success
web-password-updated => Password update success
web-add-callout => "Add the Save" Callout on Explore/Collections
web-library-callout => "Personal Library" Callout on Explore
```