### PR TITLE
buidl(ci): use dlx (download & execute)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
           fingerprints:
             - '95:3f:a9:02:0d:06:71:f9:5d:90:1e:a0:e5:e3:c3:25'
       # Semantic Release
-      - run: pnpm exec semantic-release
+      - run: pnpm dlx semantic-release
       - run:
           name: Check for new release
           command: |


### PR DESCRIPTION
## Goals

DLX is the proper one since we don't actually download the base `semantic-release` package
## To Do:
