### PR TITLE
feat(api): revalidate static pages

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -186,6 +186,10 @@ private getSecretsManagerKmsAlias() {
               {
                 name: 'BRAZE_PRIVATE_KEY',
                 valueFrom: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/BRAZE_PRIVATE_KEY`
+              },
+              {
+                name: 'REVALIDATION_TOKEN',
+                valueFrom: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/REVALIDATION_TOKEN`
               }
             ],
             logMultilinePattern: '^\\S.+',

--- a/next.config.js
+++ b/next.config.js
@@ -14,7 +14,8 @@ const nextOptions = {
   env: {
     SHOW_DEV: process.env.SHOW_DEV,
     RELEASE_VERSION: process.env.RELEASE_VERSION,
-    TEST_SNOWPLOW: process.env.TEST_SNOWPLOW
+    TEST_SNOWPLOW: process.env.TEST_SNOWPLOW,
+    REVALIDATION_TOKEN: process.env.REVALIDATION_TOKEN
   },
   compiler: {
     emotion: true

--- a/src/pages/api/revalidate.ts
+++ b/src/pages/api/revalidate.ts
@@ -1,0 +1,57 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // Check for secret to confirm this is a valid request
+  if (req.query.secret !== process.env.REVALIDATION_TOKEN) {
+    return res.status(401).json({ message: 'Invalid token' })
+  }
+
+  try {
+    // this should be the actual path not a rewritten path
+    // e.g. for "/blog/[slug]" this should be "/blog/post-1"
+    await res.revalidate('/home')
+
+    await res.revalidate('/saves')
+
+    await res.revalidate('/saves/archive')
+    await res.revalidate('/saves/archive/unread')
+    await res.revalidate('/saves/archive/favorites')
+
+    await res.revalidate('/saves/favorites')
+    await res.revalidate('/saves/favorites/unread')
+    await res.revalidate('/saves/favorites/archive')
+
+    await res.revalidate('/saves/highlights')
+    await res.revalidate('/saves/highlights/unread')
+    await res.revalidate('/saves/highlights/archive')
+    await res.revalidate('/saves/highlights/favorites')
+
+    await res.revalidate('/saves/articles')
+    await res.revalidate('/saves/articles/unread')
+    await res.revalidate('/saves/articles/archive')
+    await res.revalidate('/saves/articles/favorites')
+
+    await res.revalidate('/saves/videos')
+    await res.revalidate('/saves/videos/unread')
+    await res.revalidate('/saves/videos/archive')
+    await res.revalidate('/saves/videos/favorites')
+
+    await res.revalidate('/saves/search')
+    await res.revalidate('/saves/search/unread')
+    await res.revalidate('/saves/search/archive')
+    await res.revalidate('/saves/search/favorites')
+
+    await res.revalidate('/saves/search')
+    await res.revalidate('/saves/search/unread')
+    await res.revalidate('/saves/search/archive')
+    await res.revalidate('/saves/search/favorites')
+
+    await res.revalidate('/saves/tags')
+
+    return res.json({ revalidated: true })
+  } catch (err) {
+    // If there was an error, Next.js will continue
+    // to show the last successfully generated page
+    return res.status(500).send('Error revalidating')
+  }
+}


### PR DESCRIPTION
## Goals

Before we go and make all pages revalidate at all times, let's try this. This creates a very basic api to revalidate saves pages


## To Do:

- [x] Build a revalidation endpoint for `/home` `/saves/*`
- [x] Set up env in next for security(ish)
- [ ] Set up env in deployments (docker/aws/etc) — Need help from @bassrock 

