### PR TITLE
fix(release): tag correctly w/out husky check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
           fingerprints:
             - '95:3f:a9:02:0d:06:71:f9:5d:90:1e:a0:e5:e3:c3:25'
       # Semantic Release
-      - run: pnpm dlx semantic-release
+      - run: HUSKY=0 pnpm dlx semantic-release
       - run:
           name: Check for new release
           command: |

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,6 @@
 constants.js
 actions.js
 fonts.js
+
+// Ignore circleCI confgig
+.circleci/config.yml


### PR DESCRIPTION
## Goals

Husky doesn't need to run during a semantic release

## To Do:

- [x] Husky=0 to suppress Husky
- [x] BONUS: Stop prettier from clobbering the YML file