### PR TITLE
fix(lists): validate analytics exist before firing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  snowplow:
+    image: pocket/snowplow-micro:prod
+    ports:
+      - '9090:9090'

--- a/src/connectors/lists/list.card.js
+++ b/src/connectors/lists/list.card.js
@@ -40,7 +40,8 @@ export const ListCard = ({ id, position }) => {
   const onImageFail = () => dispatch(setNoImage(id))
 
   const onItemInView = (inView) => {
-    if (!impressionFired && inView) {
+    const validAnalytics = !!passedAnalytics?.shareableListExternalId
+    if (!impressionFired && inView && validAnalytics) {
       dispatch(sendSnowplowEvent('shareable-list.impression', analyticsData))
     }
   }


### PR DESCRIPTION
## Goals

Snowplow analytics on Lists page was throwing a bunch of errors.  Was able to replicate by:

a) Visit the page (initial analytics are fired just fine)
b) Visit another server rendered page (discover, collections, public lists pages)
c) Use the back button to return to `all lists page` 

Snowplow analytics payload is stored independently of the flat list of ids used to iterate over the list.  What was happening is the id's were being looped over, but contained no data... so snowplow would fire, but errored out ... once the item data came in, it would fire again.

There is probably a broader architecture update that needs to happen here, but for now, we can just validate the data before we send it. 

## To Do:

- [x] Base line validation that the passed analytics aren't empty
- [x] Add `docker-compose.yml` so we can test snowplow locally

## Next steps

Need to figure out the future of lists and continue to clean up patterns across the repo to root this stuff out