### PR TITLE
fix(constants): add mastodon cache key value

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -75,6 +75,9 @@ export const SNOWPLOW_ANONYMOUS_CONFIG = {
   anonymousTracking: { withServerAnonymisation: true },
 }
 
+// Mastodon 
+export const CACHE_KEY_MASTODON_INSTANCE = 'preferred-mastodon-instance'
+
 export const KEYS = {
   BACKSPACE: 8,
   TAB: 9,


### PR DESCRIPTION
## Goals

This key didn't actually exist ... so value were simply set to `undefined` ... this updates that so we have an actual string value as a key


## To Do:

- [x] export `CACHE_KEY_MASTODON_INSTANCE`

