### PR TITLE
fix(referrer): ensure we send a referrer always

### DIFF
--- a/clients/web/src/components/account/rss/rss.js
+++ b/clients/web/src/components/account/rss/rss.js
@@ -21,33 +21,21 @@ const RssLinks = ({ userName }) => {
       <label htmlFor="something" className="connectionLabel">
         {t('account:rss-view-unread', 'View RSS feed of unread items')}
       </label>
-      <a
-        href={unreadLink}
-        className="button secondary actionInline"
-        target="_blank"
-        rel="noopener noreferrer">
+      <a href={unreadLink} className="button secondary actionInline" target="_blank" rel="noopener">
         {t('account:rss-open-feed', 'Open Feed')}
       </a>
 
       <label htmlFor="something" className="connectionLabel">
         {t('account:rss-view-archived', 'View RSS feed of archived items')}
       </label>
-      <a
-        href={readLink}
-        className="button secondary actionInline"
-        target="_blank"
-        rel="noopener noreferrer">
+      <a href={readLink} className="button secondary actionInline" target="_blank" rel="noopener">
         {t('account:rss-open-feed', 'Open Feed')}
       </a>
 
       <label htmlFor="something" className="connectionLabel">
         {t('account:rss-view-all', 'View RSS feed of all items')}
       </label>
-      <a
-        href={allLink}
-        className="button secondary actionInline"
-        target="_blank"
-        rel="noopener noreferrer">
+      <a href={allLink} className="button secondary actionInline" target="_blank" rel="noopener">
         {t('account:rss-open-feed', 'Open Feed')}
       </a>
       <div className="helperText full">

--- a/clients/web/src/components/call-out/call-out-build-home.js
+++ b/clients/web/src/components/call-out/call-out-build-home.js
@@ -154,7 +154,6 @@ export function CallOutBuildHome({ topBorder }) {
           id="explore-signup-hero" // needed for snowplow identifier
           className="button brand"
           target="_blank"
-          rel="noreferrer"
           href={`${SIGNUP_URL}?src=web-add-callout&utm_source=${global.location.href}&utm_medium=web`}>
           {t('call-out:sign-up', 'Sign Up')}
         </a>

--- a/clients/web/src/components/call-out/call-out-pocket-hits.js
+++ b/clients/web/src/components/call-out/call-out-pocket-hits.js
@@ -284,17 +284,11 @@ const CallOutPocketHitsSignup = ({
                   <div className="captchaDisclaimer">
                     {t('call-out:pocket-hits-description', 'This site is protected by reCAPTCHA.')}
                     <span>
-                      <a
-                        href="https://policies.google.com/privacy"
-                        target="_blank"
-                        rel="noopener noreferrer">
+                      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">
                         {t('call-out:privacy', 'Privacy')}
                       </a>
                       &nbsp;·&nbsp;
-                      <a
-                        href="https://policies.google.com/terms"
-                        target="_blank"
-                        rel="noopener noreferrer">
+                      <a href="https://policies.google.com/terms" target="_blank" rel="noopener">
                         {t('call-out:terms', 'Terms')}
                       </a>
                     </span>

--- a/clients/web/src/components/call-out/call-out-start-library.js
+++ b/clients/web/src/components/call-out/call-out-start-library.js
@@ -148,7 +148,6 @@ export function CallOutStartLibrary({
           <a
             className="button primary start-button"
             target="_blank"
-            rel="noreferrer"
             onClick={handleButtonClick}
             href={`${SIGNUP_URL}?src=web-library-callout&utm_source=${global.location.href}&utm_medium=web`}>
             {t('discover:start-your-library', 'Start your library')}

--- a/clients/web/src/components/content-partner/partner.js
+++ b/clients/web/src/components/content-partner/partner.js
@@ -47,7 +47,7 @@ export function Partner({ partnerInfo }) {
   return (
     <div className={partnerStyles}>
       <div>{attribution}</div>
-      <a href={partnerInfo.url} target="_blank" rel="noopener noreferrer">
+      <a href={partnerInfo.url} target="_blank" rel="noopener">
         <img src={partnerInfo.imageUrl} alt={partnerInfo.name} />
       </a>
     </div>

--- a/clients/web/src/components/content-publisher/publisher-attribution.js
+++ b/clients/web/src/components/content-publisher/publisher-attribution.js
@@ -70,8 +70,7 @@ function FollowPublisher({ leadIn, text, url, handleImpression, handleClick }) {
           onClick={onClick}
           href={url}
           /* eslint-disable-next-line */
-          target="_blank"
-          rel="noreferrer">
+          target="_blank">
           {text}
         </a>
       </div>

--- a/clients/web/src/components/content-recs/publisher-recs.js
+++ b/clients/web/src/components/content-recs/publisher-recs.js
@@ -85,12 +85,7 @@ const RecommendedArticle = ({
   return (
     <VisibilitySensor onVisible={handleVisible}>
       <li className={recommendedArticleStyles} data-testid="publisher-recs-article">
-        <a
-          onClick={handleClick}
-          className="title"
-          href={url}
-          target="_blank"
-          rel="noopener noreferrer">
+        <a onClick={handleClick} className="title" href={url} target="_blank" rel="noopener">
           {title}
         </a>
       </li>

--- a/clients/web/src/components/global-footer/global-footer.js
+++ b/clients/web/src/components/global-footer/global-footer.js
@@ -310,7 +310,7 @@ export const GlobalFooter = (props) => {
       className={appStoreBadgeStyle}
       key="footer-app-store-badge"
       target="_blank"
-      rel="noopener noreferrer">
+      rel="noopener">
       <img
         src={appStoreBadge}
         alt={t('global-footer:app-store', 'Download On the Apple App Store')}
@@ -321,7 +321,7 @@ export const GlobalFooter = (props) => {
       className={`${appStoreBadgeStyle} google-play-badge`}
       key="footer-google-play-badge"
       target="_blank"
-      rel="noopener noreferrer">
+      rel="noopener">
       <img src={googlePlayBadge} alt={t('global-footer:google-play', 'Get It On Google Play')} />
     </a>
   ]
@@ -412,7 +412,7 @@ export const GlobalFooter = (props) => {
             <span>
               <Trans i18nKey="global-footer:pocket-is-part-of">
                 Pocket is part of the{' '}
-                <a href="https://www.mozilla.org/about/" target="_blank" rel="noopener noreferrer">
+                <a href="https://www.mozilla.org/about/" target="_blank" rel="noopener">
                   Mozilla
                 </a>{' '}
                 family of products.
@@ -448,21 +448,21 @@ export const GlobalFooter = (props) => {
               <div className="social-wrapper">
                 {t('global-footer:follow-pocket', 'Follow Pocket')}
                 <div className="social">
-                  <a href="https://facebook.com/pocket" target="_blank" rel="noopener noreferrer">
+                  <a href="https://facebook.com/pocket" target="_blank" rel="noopener">
                     <FacebookMonoIcon
                       id="facebook-footer-icon"
                       title="Facebook"
                       description={t('global-footer:visit-facebook', 'Visit our Facebook page')}
                     />
                   </a>
-                  <a href="https://twitter.com/pocket" target="_blank" rel="noopener noreferrer">
+                  <a href="https://twitter.com/pocket" target="_blank" rel="noopener">
                     <TwitterMonoIcon
                       id="twitter-footer-icon"
                       title="Twitter"
                       description={t('global-footer:view-twitter', 'View our Twitter profile')}
                     />
                   </a>
-                  <a href="https://instagram.com/pocket" target="_blank" rel="noopener noreferrer">
+                  <a href="https://instagram.com/pocket" target="_blank" rel="noopener">
                     <InstagramMonoIcon
                       id="instagram-footer-icon"
                       title="Instagram"

--- a/clients/web/src/components/item-card/card.js
+++ b/clients/web/src/components/item-card/card.js
@@ -144,7 +144,7 @@ export const Card = (props) => {
 
   const openInNewTab = !isInternalItem
   const linkTarget = openInNewTab ? '_blank' : undefined
-  const linkRel = openInNewTab ? 'noopener noreferrer' : undefined
+  const linkRel = openInNewTab ? 'noopener' : undefined
 
   return (
     <article
@@ -214,7 +214,7 @@ export const Card = (props) => {
                     data-testid="publisher-link"
                     tabIndex={0}
                     target="_blank"
-                    rel="noopener noreferrer">
+                    rel="noopener">
                     {publisher}
                   </a>
                 ) : (

--- a/clients/web/src/components/item/actions/overflow.js
+++ b/clients/web/src/components/item/actions/overflow.js
@@ -66,8 +66,7 @@ const MenuPopover = function ({ popoverRef, menuItems }) {
             data-testid={label}
             className={popoverMenuItem}
             onClick={onClick}
-            target="_blank"
-            rel="noreferrer">
+            target="_blank">
             {icon ? icon : null}
             {label}
           </a>

--- a/clients/web/src/components/item/actions/saved.js
+++ b/clients/web/src/components/item/actions/saved.js
@@ -142,8 +142,7 @@ export function VisibleAction({ actions }) {
         aria-label={label}
         data-testid={label}
         onClick={onClick}
-        target="_blank"
-        rel="noreferrer">
+        target="_blank">
         {icon}
       </a>
     ) : (

--- a/clients/web/src/components/item/item-media.js
+++ b/clients/web/src/components/item/item-media.js
@@ -117,7 +117,7 @@ export const CardMedia = function ({
 
   const { t } = useTranslation()
   const linkTarget = openInNewTab ? '_blank' : ''
-  const linkRel = openInNewTab ? 'noopener noreferrer' : ''
+  const linkRel = openInNewTab ? 'noopener' : ''
 
   const MediaImage = () => {
     return hasImage ? (

--- a/clients/web/src/components/item/item.js
+++ b/clients/web/src/components/item/item.js
@@ -95,7 +95,7 @@ export const Item = (props) => {
 
   const openInNewTab = !isInternalItem
   const linkTarget = openInNewTab ? '_blank' : undefined
-  const linkRel = openInNewTab ? 'noopener noreferrer' : undefined
+  const linkRel = openInNewTab ? 'noopener' : undefined
   const [tagsShown, setTagsShown] = useState(false)
 
   const viewRef = useRef(null)
@@ -291,7 +291,7 @@ const Publisher = ({ publisher, externalUrl, onOpenOriginalUrl, isSyndicated }) 
           data-testid="publisher-link"
           tabIndex={0}
           target="_blank"
-          rel="noopener noreferrer">
+          rel="noopener">
           {publisher}
         </a>
       ) : (

--- a/clients/web/src/components/item/item.signaled.js
+++ b/clients/web/src/components/item/item.signaled.js
@@ -84,7 +84,7 @@ export const ItemSignaled = (props) => {
 
   const openInNewTab = !isInternalItem
   const linkTarget = openInNewTab ? '_blank' : undefined
-  const linkRel = openInNewTab ? 'noopener noreferrer' : undefined
+  const linkRel = openInNewTab ? 'noopener' : undefined
 
   const viewRef = useRef(null)
   const linkRef = useRef(null)
@@ -235,7 +235,7 @@ const Publisher = ({ publisher, externalUrl, onOpenOriginalUrl, isSyndicated }) 
           data-testid="publisher-link"
           tabIndex={0}
           target="_blank"
-          rel="noopener noreferrer">
+          rel="noopener">
           {publisher}
         </a>
       ) : (

--- a/clients/web/src/components/items-media/card-media.js
+++ b/clients/web/src/components/items-media/card-media.js
@@ -123,7 +123,7 @@ export const CardMedia = function ({
 
   const { t } = useTranslation()
   const linkTarget = openInNewTab ? '_blank' : ''
-  const linkRel = openInNewTab ? 'noopener noreferrer' : ''
+  const linkRel = openInNewTab ? 'noopener' : ''
 
   const MediaImage = () => {
     return hasImage ? (

--- a/clients/web/src/components/pocket-hits-chyron/pocket-hits-illustrated-chyron.js
+++ b/clients/web/src/components/pocket-hits-chyron/pocket-hits-illustrated-chyron.js
@@ -262,17 +262,11 @@ const PocketHitsIllustratedChyron = ({
               <div className={captchaDisclaimer}>
                 This site is protected by reCAPTCHA.&nbsp;
                 <span>
-                  <a
-                    href="https://policies.google.com/privacy"
-                    target="_blank"
-                    rel="noopener noreferrer">
+                  <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">
                     Privacy
                   </a>
                   &nbsp;·&nbsp;
-                  <a
-                    href="https://policies.google.com/terms"
-                    target="_blank"
-                    rel="noopener noreferrer">
+                  <a href="https://policies.google.com/terms" target="_blank" rel="noopener">
                     Terms
                   </a>
                 </span>

--- a/clients/web/src/components/reader/content.js
+++ b/clients/web/src/components/reader/content.js
@@ -51,7 +51,7 @@ export const Content = ({
     const links = articleRef.current.querySelectorAll('a[href]')
     links.forEach((link, index) => {
       link.setAttribute('target', '_blank')
-      link.setAttribute('rel', 'noopener noreferrer')
+      link.setAttribute('rel', 'noopener')
       link.setAttribute('id', `reader.external-link.num-${index}`)
       link.addEventListener('click', sendExternalLinkClick)
     })

--- a/clients/web/src/components/reader/header.js
+++ b/clients/web/src/components/reader/header.js
@@ -163,7 +163,7 @@ export const ItemHeader = ({
           onClick={viewOriginalEvent}
           href={externalUrl}
           target="_blank"
-          rel="noopener noreferrer">
+          rel="noopener">
           <Trans i18nKey="reader:view-original">View Original</Trans>
           <NewViewIcon />
         </a>

--- a/clients/web/src/components/reader/upsell.bottom.js
+++ b/clients/web/src/components/reader/upsell.bottom.js
@@ -228,7 +228,6 @@ const LibraryAd = () => (
         data-testid="reader-bottom-premium"
         className="button primary"
         target="_blank"
-        rel="noreferrer"
         href={premiumURL}>
         <Trans i18nKey="reader:upgrade">Upgrade</Trans>
       </a>
@@ -272,7 +271,6 @@ const SearchAd = () => (
         data-testid="reader-bottom-premium"
         className="button primary"
         target="_blank"
-        rel="noreferrer"
         href={premiumURL}>
         <Trans i18nKey="reader:upgrade">Upgrade</Trans>
       </a>
@@ -316,7 +314,6 @@ const FocusedAd = () => (
         data-testid="reader-bottom-premium"
         className="button primary"
         target="_blank"
-        rel="noreferrer"
         href={premiumURL}>
         <Trans i18nKey="reader:upgrade">Upgrade</Trans>
       </a>
@@ -348,8 +345,7 @@ const TypeAd = () => (
           id="reader.bottom.premium.type"
           dataCy="reader-bottom-premium"
           href={premiumURL}
-          target="_blank"
-          rel="noreferrer">
+          target="_blank">
           <Trans i18nKey="reader:pocket-premium">Pocket Premium</Trans>
         </ArrowLink>
       </p>
@@ -361,7 +357,6 @@ const TypeAd = () => (
         data-testid="reader-bottom-premium"
         className="button primary"
         target="_blank"
-        rel="noreferrer"
         href={premiumURL}>
         <Trans i18nKey="reader:upgrade">Upgrade</Trans>
       </a>
@@ -393,8 +388,7 @@ const BigDiamondAd = () => (
           id="reader.bottom.premium.features"
           dataCy="reader-bottom-premium"
           href={premiumURL}
-          target="_blank"
-          rel="noreferrer">
+          target="_blank">
           <Trans i18nKey="reader:pocket-premium">Pocket Premium</Trans>
         </ArrowLink>
       </p>
@@ -406,7 +400,6 @@ const BigDiamondAd = () => (
         data-testid="reader-bottom-premium"
         className="button primary"
         target="_blank"
-        rel="noreferrer"
         href={premiumURL}>
         <Trans i18nKey="reader:upgrade">Upgrade</Trans>
       </a>
@@ -450,7 +443,6 @@ const HighlightAd = () => (
         data-testid="reader-bottom-premium"
         className="button primary"
         target="_blank"
-        rel="noreferrer"
         href={premiumURL}>
         <Trans i18nKey="reader:upgrade">Upgrade</Trans>
       </a>
@@ -494,7 +486,6 @@ const TagsAd = () => (
         data-testid="reader-bottom-premium"
         className="button primary"
         target="_blank"
-        rel="noreferrer"
         href={premiumURL}>
         <Trans i18nKey="reader:upgrade">Upgrade</Trans>
       </a>

--- a/clients/web/src/connectors/dev-tools/braze.js
+++ b/clients/web/src/connectors/dev-tools/braze.js
@@ -12,7 +12,7 @@ export const BrazeTools = () => {
   const brazeToken = useSelector((state) => state.userBraze?.token)
 
   useEffect(() => {
-    if (!brazeInitialized) return () => {} 
+    if (!brazeInitialized) return () => {}
     import('common/utilities/braze/braze-lazy-load').then(
       ({ isPushBlocked, isPushPermissionGranted }) => {
         if (isPushBlocked()) setPushDenied(true)
@@ -56,8 +56,7 @@ export const BrazeTools = () => {
             <br />
             <a
               href="https://support.mozilla.org/en-US/kb/push-notifications-firefox#w_upgraded-notifications"
-              target="_blank"
-              rel="noreferrer">
+              target="_blank">
               Please update your settings
             </a>
           </div>

--- a/clients/web/src/containers/collections/stories-page/card.spec.js.snap
+++ b/clients/web/src/containers/collections/stories-page/card.spec.js.snap
@@ -17,7 +17,7 @@ exports[`ItemCard renders a story 1`] = `
       <a
         data-testid="image-link"
         href="https://www.nytimes.com/2017/05/06/business/inside-vws-campaign-of-trickery.html?utm_source=pocket_collection_story"
-        rel="noopener noreferrer"
+        rel="noopener"
         tabindex="-1"
         target="_blank"
       >
@@ -66,7 +66,7 @@ exports[`ItemCard renders a story 1`] = `
         <a
           data-testid="title-link"
           href="https://www.nytimes.com/2017/05/06/business/inside-vws-campaign-of-trickery.html?utm_source=pocket_collection_story"
-          rel="noopener noreferrer"
+          rel="noopener"
           tabindex="0"
           target="_blank"
         >
@@ -106,7 +106,7 @@ exports[`ItemCard renders a story 1`] = `
           class="publisher"
           data-testid="publisher-link"
           href="https://www.nytimes.com/2017/05/06/business/inside-vws-campaign-of-trickery.html?utm_source=pocket_collection_story"
-          rel="noopener noreferrer"
+          rel="noopener"
           tabindex="0"
           target="_blank"
         >

--- a/clients/web/src/containers/pocket-hits-signup/pocket-hits-signup.js
+++ b/clients/web/src/containers/pocket-hits-signup/pocket-hits-signup.js
@@ -302,11 +302,11 @@ export default function PocketHitsSignupPage({ language = 'en' }) {
 
                     <div className={formSubtextWrapper}>
                       <span className={formSubtextLinks}>
-                        <a href="/privacy" target="_blank" rel="noopener noreferrer">
+                        <a href="/privacy" target="_blank" rel="noopener">
                           Privacy
                         </a>
                         <span>·</span>
-                        <a href="/tos" target="_blank" rel="noopener noreferrer">
+                        <a href="/tos" target="_blank" rel="noopener">
                           Terms
                         </a>
                       </span>

--- a/ui/components/__snapshots__/layout-main.ts.snap
+++ b/ui/components/__snapshots__/layout-main.ts.snap
@@ -225,7 +225,7 @@ exports[`renders LayoutMain with defaults 1`] = `
                 >
                   <a
                     href="https://facebook.com/pocket"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                     target="_blank"
                     title="Visit our Facebook page"
                   >
@@ -245,7 +245,7 @@ exports[`renders LayoutMain with defaults 1`] = `
                   </a>
                   <a
                     href="https://twitter.com/pocket"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                     target="_blank"
                     title="View our Twitter profile"
                   >
@@ -265,7 +265,7 @@ exports[`renders LayoutMain with defaults 1`] = `
                   </a>
                   <a
                     href="https://instagram.com/pocket"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                     target="_blank"
                     title="Find us on Instagram"
                   >
@@ -301,7 +301,7 @@ exports[`renders LayoutMain with defaults 1`] = `
           </h6>
           <a
             href="https://apps.apple.com/us/app/pocket-save-read-grow/id309601447"
-            rel="noopener noreferrer"
+            rel="noopener"
             target="_blank"
             title="Download On the Apple App Store"
           >
@@ -317,7 +317,7 @@ exports[`renders LayoutMain with defaults 1`] = `
           <a
             class="google-play-badge"
             href="https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro"
-            rel="noopener noreferrer"
+            rel="noopener"
             target="_blank"
             title="Get It On Google Play"
           >
@@ -342,7 +342,7 @@ exports[`renders LayoutMain with defaults 1`] = `
                
               <a
                 href="https://www.mozilla.org/about/"
-                rel="noopener noreferrer"
+                rel="noopener"
                 target="_blank"
               >
                 Mozilla

--- a/ui/components/__snapshots__/nav-footer.ts.snap
+++ b/ui/components/__snapshots__/nav-footer.ts.snap
@@ -123,7 +123,7 @@ exports[`renders NavFooter with defaults 1`] = `
               >
                 <a
                   href="https://facebook.com/pocket"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                   target="_blank"
                   title="Visit our Facebook page"
                 >
@@ -143,7 +143,7 @@ exports[`renders NavFooter with defaults 1`] = `
                 </a>
                 <a
                   href="https://twitter.com/pocket"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                   target="_blank"
                   title="View our Twitter profile"
                 >
@@ -163,7 +163,7 @@ exports[`renders NavFooter with defaults 1`] = `
                 </a>
                 <a
                   href="https://instagram.com/pocket"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                   target="_blank"
                   title="Find us on Instagram"
                 >
@@ -199,7 +199,7 @@ exports[`renders NavFooter with defaults 1`] = `
         </h6>
         <a
           href="https://apps.apple.com/us/app/pocket-save-read-grow/id309601447"
-          rel="noopener noreferrer"
+          rel="noopener"
           target="_blank"
           title="Download On the Apple App Store"
         >
@@ -215,7 +215,7 @@ exports[`renders NavFooter with defaults 1`] = `
         <a
           class="google-play-badge"
           href="https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro"
-          rel="noopener noreferrer"
+          rel="noopener"
           target="_blank"
           title="Get It On Google Play"
         >
@@ -240,7 +240,7 @@ exports[`renders NavFooter with defaults 1`] = `
              
             <a
               href="https://www.mozilla.org/about/"
-              rel="noopener noreferrer"
+              rel="noopener"
               target="_blank"
             >
               Mozilla

--- a/ui/components/nav-footer/index.tsx
+++ b/ui/components/nav-footer/index.tsx
@@ -96,21 +96,21 @@ export function NavFooter() {
                 <div className={style.social}>
                   <a
                     href="https://facebook.com/pocket"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                     target="_blank"
                     title={t('global-footer:visit-facebook', 'Visit our Facebook page')}>
                     <FacebookMonoIcon />
                   </a>
                   <a
                     href="https://twitter.com/pocket"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                     target="_blank"
                     title={t('global-footer:view-twitter', 'View our Twitter profile')}>
                     <TwitterMonoIcon />
                   </a>
                   <a
                     href="https://instagram.com/pocket"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                     target="_blank"
                     title={t('global-footer:view-instagram', 'Find us on Instagram')}>
                     <InstagramMonoIcon />
@@ -124,7 +124,7 @@ export function NavFooter() {
           <h6>{t('global-footer:get-the-app', 'Get the app')}</h6>
           <a
             href="https://apps.apple.com/us/app/pocket-save-read-grow/id309601447"
-            rel="noopener noreferrer"
+            rel="noopener"
             target="_blank"
             title={t('global-footer:app-store', 'Download On the Apple App Store')}>
             <svg height="40" width="119.664">
@@ -134,7 +134,7 @@ export function NavFooter() {
           <a
             className="google-play-badge"
             href="https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro"
-            rel="noopener noreferrer"
+            rel="noopener"
             target="_blank"
             title={t('global-footer:google-play', 'Get It On Google Play')}>
             <svg height="40.37" width="135.12">
@@ -147,7 +147,7 @@ export function NavFooter() {
             <div className={style.partOf}>
               <Trans i18nKey="global-footer:pocket-is-part-of">
                 Pocket is part of the{' '}
-                <a href="https://www.mozilla.org/about/" rel="noopener noreferrer" target="_blank">
+                <a href="https://www.mozilla.org/about/" rel="noopener" target="_blank">
                   Mozilla
                 </a>{' '}
                 family of products.


### PR DESCRIPTION
## Goals

I noticed we were never sending the referrer on any links. As far as I can tell there is no reason to _not_ send this and this will give us insight on where users are navigating from. While snowplow gives some data, depending on cookie settings we can't map sessions together fully.

This also ensures that when we send publishers traffic they know it came from Pocket.

## To Do:

- [x] Figure out what I am missing? Did SEO team tell us to turn this off? Security?
- [ ] Find out the best way to make friends. I'm told cookies help. Also whats a honeydoodle?

![scratching-head-confusion-the-simpsons-fq6aayvfuwojf6uc](https://github.com/Pocket/web-client/assets/1010384/f3358172-4235-48db-bb40-0aec355b3516)
