### PR TITLE
feat(syndicated): add meta `syndicatedFrom`

### DIFF
--- a/clients/web/src/containers/_layouts/_head.js
+++ b/clients/web/src/containers/_layouts/_head.js
@@ -2,7 +2,14 @@ import Head from 'next/head'
 import { getImageCacheUrl } from 'common/utilities/urls/urls'
 import { FACEBOOK_APP_ID } from 'common/constants'
 
-export const PocketHead = ({ metaData = {}, title: pageTitle, canonical, noIndex, forceWebView }) => {
+export const PocketHead = ({
+  metaData = {},
+  title: pageTitle,
+  canonical,
+  syndicatedFrom,
+  noIndex,
+  forceWebView
+}) => {
   const { url = '', description = '', title = '', type = 'website', image } = metaData
 
   const twitterCardType = image ? 'summary_large_image' : 'summary'
@@ -25,6 +32,7 @@ export const PocketHead = ({ metaData = {}, title: pageTitle, canonical, noIndex
 
       {/*  Pocket Specific Tags */}
       <meta name="x-pocket-override-excerpt" content={description} />
+      {syndicatedFrom ? <meta name="pocket:syndicated-from" content={syndicatedFrom} /> : null}
 
       {/* Schema.org for Google */}
       <meta itemProp="name" content={title} />

--- a/clients/web/src/containers/_layouts/fxa.tsx
+++ b/clients/web/src/containers/_layouts/fxa.tsx
@@ -19,16 +19,25 @@ function mainLayout({
   metaData,
   children,
   title = 'Pocket',
-  canonical
+  canonical,
+  syndicatedFrom
 }: {
   metaData?: metaData
   children: ReactNode
   title?: string
   canonical?: string
+  syndicatedFrom?: string
 }) {
   return (
     <>
-      <PocketHead title={title} canonical={canonical} metaData={metaData} forceWebView={true} noIndex={false}/>
+      <PocketHead
+        title={title}
+        canonical={canonical}
+        syndicatedFrom={syndicatedFrom}
+        metaData={metaData}
+        forceWebView={true}
+        noIndex={false}
+      />
       <GlobalNav onlyLogout={true} />
       <div className={cx(fixedNavContainer)}>{children}</div>
     </>

--- a/clients/web/src/containers/_layouts/main.js
+++ b/clients/web/src/containers/_layouts/main.js
@@ -17,6 +17,7 @@ function mainLayout({
   children,
   title = 'Pocket',
   canonical,
+  syndicatedFrom,
   noIndex,
   noNav = false,
   selectedNavLink,
@@ -31,6 +32,7 @@ function mainLayout({
         title={title}
         noIndex={noIndex}
         canonical={canonical}
+        syndicatedFrom={syndicatedFrom}
         metaData={metaData}
         forceWebView={forceWebView}
       />

--- a/clients/web/src/containers/syndicated-article/syndicated-article.js
+++ b/clients/web/src/containers/syndicated-article/syndicated-article.js
@@ -62,6 +62,7 @@ export function SyndicatedArticle({ queryParams = validParams, locale }) {
     title,
     excerpt,
     publisher,
+    publisherUrl,
     authorNames,
     content,
     publishedAt,
@@ -104,7 +105,7 @@ export function SyndicatedArticle({ queryParams = validParams, locale }) {
   // This means we don't inadvertently clobber or steal publisher SEO
   const canonical = false
   const noIndex = publisher?.attributeCanonicalToPublisher
-
+  const syndicatedFrom = publisherUrl ? publisherUrl : false
   const ArticleLayout = isMobileWebView ? MobileLayout : Layout
 
   const saveAction = (savedUrl, value) => {
@@ -162,6 +163,7 @@ export function SyndicatedArticle({ queryParams = validParams, locale }) {
       <ArticleLayout
         title={title}
         metaData={articleMetaData}
+        syndicatedFrom={syndicatedFrom}
         canonical={canonical}
         noIndex={noIndex}
         className={printLayout}>


### PR DESCRIPTION
## Goals

Add a meta to show where we syndicated an article from. This will help clarity of data when we parse our own syndicated articles.

## To Do:

- [x] Add syndicatedFrom to layout
- [x] Pass syndicatedFrom along

![Screenshot 2024-04-26 at 11 55 42 AM](https://github.com/Pocket/web-client/assets/16119672/1f7dee8e-e0b2-42bf-b509-70b7ac7c9622)
