### PR TITLE
fix(snowplow): adding in new snowplow contexts and user ids

### DIFF
--- a/clients/web/src/common/constants.js
+++ b/clients/web/src/common/constants.js
@@ -65,7 +65,7 @@ export const SNOWPLOW_CONFIG = {
   eventMethod: 'beacon',
   respectDoNotTrack: false, // temporary to determine impact
   stateStorageStrategy: 'cookieAndLocalStorage',
-  contexts: { webPage: true, performanceTiming: true },
+  contexts: { webPage: true, performanceTiming: true, session: true, browser: true },
   postPath: SNOWPLOW_POST_PATH
 }
 export const SNOWPLOW_ANONYMOUS_CONFIG = {
@@ -73,6 +73,8 @@ export const SNOWPLOW_ANONYMOUS_CONFIG = {
   eventMethod: 'post', // over-rides eventMethod: post
   stateStorageStrategy: 'none', // over-rides stateStorageStrategy: cookieAndLocalStorage
   anonymousTracking: { withServerAnonymisation: true },
+  // no session context on anonymous config
+  contexts: { webPage: true, performanceTiming: true, session: false, browser: true },
 }
 
 // Mastodon 

--- a/clients/web/src/common/setup/snowplow.js
+++ b/clients/web/src/common/setup/snowplow.js
@@ -28,8 +28,14 @@ export function initializeSnowplow(user_id, sess_guid, cookied, finalizeInit) {
     if (!snowplow) throw new SnowplowInjectionError()
 
     // configure snowplow
-    const snowplowConfig = (cookied) ? SNOWPLOW_CONFIG : SNOWPLOW_ANONYMOUS_CONFIG
+    const snowplowConfig = cookied ? SNOWPLOW_CONFIG : SNOWPLOW_ANONYMOUS_CONFIG
     snowplow('newTracker', 'sp', SNOWPLOW_COLLECTOR, snowplowConfig)
+
+    // add User entity to Snowplow global context
+    const userEntity = createUserEntity(user_id, sess_guid)
+    const globalContexts = [userEntity, apiUserEntity]
+    snowplow('setUserId', user_id)
+    snowplow('addGlobalContexts', globalContexts)
 
     // enable activity monitoring (heartbeat)
     snowplow('enableActivityTracking', {
@@ -42,11 +48,6 @@ export function initializeSnowplow(user_id, sess_guid, cookied, finalizeInit) {
 
     // automatic form elements tracking
     snowplow('enableFormTracking')
-
-    // add User entity to Snowplow global context
-    const userEntity = createUserEntity(user_id, sess_guid)
-    const globalContexts = [userEntity, apiUserEntity]
-    snowplow('addGlobalContexts', globalContexts)
 
     // no analytics cookies allowed, make sure user data is clean
     if (!cookied) snowplow('clearUserData')

--- a/clients/web/src/components/global-nav/account/global-nav-account.js
+++ b/clients/web/src/components/global-nav/account/global-nav-account.js
@@ -174,6 +174,7 @@ const GlobalNavAccount = ({
   const { t } = useTranslation()
 
   const brazeInitialized = useSelector((state) => state?.braze?.initialized)
+  const analyticsInitialized = useSelector((state) => state?.analytics?.initialized)
 
   const accountMenuTriggerRef = useRef(null)
   const menuRef = useRef(null)
@@ -215,6 +216,7 @@ const GlobalNavAccount = ({
     // Fire for all users when Braze launches
     if (brazeInitialized)
       import('common/utilities/braze/braze-lazy-load').then(({ destroy }) => destroy())
+    if (analyticsInitialized) snowplow('clearUserData')
   }
   const updateFocus = (e) => {
     if (e.charCode === KEYS.SPACE || e.charCode === KEYS.ENTER) setFocus(true)


### PR DESCRIPTION
## Goals

Enrich our analytics data with some more goodness.

* Sets our "business" user id to our hashed user id
* [Enables the Browser context](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/previous-versions/javascript-tracker-v3/tracker-setup/initialization-options/#session-context)
* [Enables the Session context](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/previous-versions/javascript-tracker-v3/tracker-setup/initialization-options/#session-context)