### PR TITLE
fix(home): add corpusRecId to id field for now

### DIFF
--- a/clients/pocket/app/(server)/api/get-home-feed/index.ts
+++ b/clients/pocket/app/(server)/api/get-home-feed/index.ts
@@ -100,6 +100,7 @@ function getItemsFromSlate({ recommendations }: { recommendations: CorpusRecomme
         ...corpusItem,
         externalUrl: corpusItem.url,
         saveUrl: corpusItem.url,
+        id: corpusRecommendationId,
         itemId: corpusRecommendationId,
         topic,
         corpusRecommendationId,

--- a/common/state/item-status/index.ts
+++ b/common/state/item-status/index.ts
@@ -40,6 +40,9 @@ export const useItemStatus = create<ItemStatus>()(
 
     /** State Action — addSave */
     addSave: async (id: string): Promise<void> => {
+      // !! This will just fail silently ... do better than this when we wire it up
+      if (!id) return
+
       try {
         // Adding Ids to SavedItemIds array optimistically
         set((state) => {
@@ -78,6 +81,9 @@ export const useItemStatus = create<ItemStatus>()(
 
     /** State Action — removeStatus */
     removeSave: async (id: string): Promise<void> => {
+      // !! This will just fail silently ... do better than this when we wire it up
+      if (!id) return
+
       try {
         // Removing id from savedItemIds array optimistically
         set((state) => {


### PR DESCRIPTION
## Goals

The id was null causing some odd behavior ... this just gives us a unique id to work with.  Shortly, we should standardize using the common item definition across all incoming items regardless of source (derivers yet again)
