### PR TITLE
fix(theme): don’t clobber body class

### DIFF
--- a/ui/components/nav-top-account-profile/index.tsx
+++ b/ui/components/nav-top-account-profile/index.tsx
@@ -47,7 +47,7 @@ export function NavTopAccountProfile() {
         crossAxis: 0
       }),
       autoPlacement({
-        allowedPlacements: ['bottom-end']
+        allowedPlacements: ['bottom-end', 'bottom-start']
       })
     ],
     whileElementsMounted: autoUpdate
@@ -61,9 +61,6 @@ export function NavTopAccountProfile() {
 
   const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss, focus])
 
-  // const handleClick = () => {
-  //   setIsOpen(false)
-  // }
   return (
     <>
       <div className={style.base} data-testid="nav-top-account-profile">
@@ -78,7 +75,7 @@ export function NavTopAccountProfile() {
 
       {isOpen ? (
         <FloatingPortal>
-          <FloatingFocusManager context={context} initialFocus={5} visuallyHiddenDismiss={true}>
+          <FloatingFocusManager context={context} modal={false} visuallyHiddenDismiss={true}>
             <div
               ref={refs.setFloating}
               style={{ ...floatingStyles, zIndex: 'var(--z-index-menu)' }}

--- a/ui/components/setting-theme/index.tsx
+++ b/ui/components/setting-theme/index.tsx
@@ -24,11 +24,21 @@ export function SettingTheme({ buttonClass = '' }: { buttonClass?: string }) {
   const updateColorMode = useUserSettings((state) => state.updateColorMode)
 
   // We want to set the mode on state AND update the body class in a non reactive way
-  const setColorMode = (mode: string) => {
-    updateColorMode(mode)
+  const setColorMode = (colorMode: string) => {
+    updateColorMode(colorMode)
 
-    // If we have a proper ref yet, swap out the class
-    if (bodyRef.current) bodyRef.current.className = `${COLOR_MODE_PREFIX}-${mode}`
+    // Set up which classes will need to be removed before adding in the current
+    // mode.  We don't want to clobber pre-existing classes
+    const validColorModes = ['system', 'dark', 'light']
+    const classesToRemove = validColorModes
+      .filter((color) => color !== colorMode)
+      .map((color) => `${COLOR_MODE_PREFIX}-${color}`)
+
+    // If we have a proper ref yet, swap out the classes
+    if (bodyRef.current) {
+      bodyRef.current.classList.remove(...classesToRemove)
+      bodyRef.current.classList.add(`${COLOR_MODE_PREFIX}-${colorMode}`)
+    }
   }
 
   // Functions for setting modes


### PR DESCRIPTION
## Goals

Small update to theme component (non-production) so it doesn't clobber the body classes.  Noticed this in storybook, but extensions and the like may also add body class