### PR TITLE
fix(permissions): add issues permission

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -30,6 +30,7 @@ on:
 permissions:
   contents: write  # This is required for actions/checkout and write to be able to write releases
   pull-requests: write # to be able to comment on released pull requests
+  issues: write # to be able to add completion to issues (which we don't use, but is still required)
   id-token: write  # Access the Github JWT for AWS access
   deployments: write
 


### PR DESCRIPTION
## Goals

SemanticRelease wants `issue` permissions if we ever decide to start using issues in gitHub so it can comment back to them ... even though we don't have issues, and turned off the ability to comment back to them.

Circle of life.  