### PR TITLE
fix(user collections): add givenUrl

### DIFF
--- a/clients/web/src/common/api/queries/get-saved-items-search.js
+++ b/clients/web/src/common/api/queries/get-saved-items-search.js
@@ -37,6 +37,7 @@ const searchSavedItemsQuery = gql`
                   timeToRead
                   shareId: id
                   itemId
+                  givenUrl
                   preview {
                     ...ItemPreview
                   }

--- a/clients/web/src/common/api/queries/get-saved-items-tagged.js
+++ b/clients/web/src/common/api/queries/get-saved-items-tagged.js
@@ -36,6 +36,7 @@ const getSavedItemsTaggedQuery = gql`
                 timeToRead
                 shareId: id
                 itemId
+                givenUrl
                 preview {
                   ...ItemPreview
                 }

--- a/clients/web/src/common/api/queries/get-saved-items.js
+++ b/clients/web/src/common/api/queries/get-saved-items.js
@@ -36,6 +36,7 @@ const getSavedItemsQuery = gql`
                 timeToRead
                 shareId: id
                 itemId
+                givenUrl
                 preview {
                   ...ItemPreview
                 }


### PR DESCRIPTION
## Goals

GivenUrl is required to add an item to a collection.  Assuming this was put in place so eventually users could add unsaved items to a collection.

