### PR TITLE
fix(sharing): adding back resolvedUrl for the derivers

### DIFF
--- a/clients/web/src/common/api/derivers/item.js
+++ b/clients/web/src/common/api/derivers/item.js
@@ -209,6 +209,8 @@ export function deriveItemData({
     publisher: publisher({ item, itemEnrichment, passedPublisher }),
     publisherLogo: item?.domainMetadata?.logo || false,
     externalUrl: externalUrl({ item, itemEnrichment, utmId }),
+    // Temporary fix for the share modal and other possible areas that need the external url
+    resolvedUrl: externalUrl({ item, itemEnrichment, utmId }),
     readUrl: readUrl({ item, node, status: node?.status }),
     itemUrl: node?.url || null,
     saveUrl: saveUrl({ item, itemEnrichment }),

--- a/clients/web/src/components/item/item.js
+++ b/clients/web/src/components/item/item.js
@@ -163,7 +163,6 @@ export const Item = (props) => {
           className="content-block"
           data-testid="content-block"
           target={linkTarget}
-          ref={linkRef}
           rel={linkRel}>
           <div className="content">
             {fromPartner ? <PartnerOverline partnerType={partnerType} /> : null}

--- a/clients/web/src/connectors/items/mutation-share.state.js
+++ b/clients/web/src/connectors/items/mutation-share.state.js
@@ -57,6 +57,7 @@ export const mutationShareSagas = [
  --------------------------------------------------------------- */
 function* getShareableLink({ item, quote, note }) {
   try {
+    //TODO: Ask @collectedmind if this should be externalUrl moving forward
     const target = item.resolvedUrl
     const context = buildContext(quote, note)
     const response = yield shareCreateLink(target, context)


### PR DESCRIPTION
## Goals

Sharing was returning an error when requesting a ShareURL because the resolvedURL was removed from the Item Deriver in favor of I think externalUrl. 

Until @collectedmind is back, fixing this by adding back the resolvedUrl in the deriver in case theres other missing areas.