### PR TITLE
fix(tags): switch out legacy mutations

### DIFF
--- a/clients/web/src/common/api/mutations/tags.ts
+++ b/clients/web/src/common/api/mutations/tags.ts
@@ -1,0 +1,41 @@
+import { gql } from 'common/utilities/gql/gql'
+import { requestGQL } from 'common/utilities/request/request'
+
+const renameTagQuery = gql`
+  mutation RenameTagByName($oldName: String!, $newName: String!) {
+    renameTagByName(oldName: $oldName, newName: $newName) {
+      name
+      id
+    }
+  }
+`
+
+export function renameTag({ oldName, newName }: { oldName: string; newName: string }) {
+  return requestGQL({
+    query: renameTagQuery,
+    variables: { oldName, newName }
+  })
+    .then((response) => {
+      const { name, id } = response?.data?.renameTagByName
+      return { name, id }
+    })
+    .catch((error) => console.error(error))
+}
+
+const deleteTagQuery = gql`
+  mutation deleteTag($tagName: String!) {
+    deleteTagByName(tagName: $tagName)
+  }
+`
+
+export function deleteTag(tagName: string) {
+  return requestGQL({
+    query: deleteTagQuery,
+    variables: { tagName }
+  })
+    .then((response) => {
+      const deletedTag = response?.data?.deleteTagByName
+      return { deletedTag }
+    })
+    .catch((error) => console.error(error))
+}

--- a/clients/web/src/common/utilities/request/request.js
+++ b/clients/web/src/common/utilities/request/request.js
@@ -121,7 +121,7 @@ export const postMime = ({ api_url = API_URL, params = {}, path, method = 'POST'
  *
  * @param {Object} data
  * @param {string} data.query Query to execute on the graph
- * @param {string} data.operationName Basic name to help identify the request (testing, logging)
+ * @param {string} [data.operationName] Basic name to help identify the request (testing, logging)
  * @param {object} data.variables Variables to use when interpolatin the query
  **/
 export const requestGQL = (data) => {

--- a/clients/web/src/containers/saves/tagged/tagged-page.state.js
+++ b/clients/web/src/containers/saves/tagged/tagged-page.state.js
@@ -1,6 +1,5 @@
 import { put, call, takeEvery, select } from 'redux-saga/effects'
-import { renameStoredTag } from 'common/api/_legacy/tags'
-import { deleteStoredTag } from 'common/api/_legacy/tags'
+import { renameTag, deleteTag } from 'common/api/mutations/tags'
 import { getUserTags as getUserTagsGraph } from 'common/api/queries/get-user-tags'
 
 import { USER_TAGS_PIN } from 'actions'
@@ -147,7 +146,7 @@ function* userTagsTogglePin(actions) {
 
 function* userTagsEditConfirm(action) {
   const { new_tag, old_tag, router } = action
-  const data = yield call(renameStoredTag, { new_tag, old_tag })
+  const data = yield call(renameTag, { oldName: old_tag, newName: new_tag })
 
   if (data) {
     const pinnedItems = yield select(getPinnedTags)
@@ -161,7 +160,7 @@ function* userTagsEditConfirm(action) {
 
 function* userTagsDeleteConfirm(action) {
   const { tag, router } = action
-  const data = yield call(deleteStoredTag, tag)
+  const data = yield call(deleteTag, tag)
 
   if (data) {
     const pinnedItems = yield select(getPinnedTags)


### PR DESCRIPTION
## Goals

Tag adjustments were still using `v3/send`. This moves them to mutations.