### PR TITLE
chore(iab): reverse map check

### DIFF
--- a/clients/web/src/common/api/queries/get-syndicated-article.js
+++ b/clients/web/src/common/api/queries/get-syndicated-article.js
@@ -87,8 +87,8 @@ export async function getSyndicatedArticle(slug) {
 
 function reverseLookupIAB(syndicatedArticleBySlug) {
   const { iabSubCategory, iabTopCategory } = syndicatedArticleBySlug
-  const iabSubCategoryId = findKeyByLabel(iabSubCategory.trim())
-  const iabTopCategoryId = findKeyByLabel(iabTopCategory.trim())
+  const iabSubCategoryId = iabSubCategory ? findKeyByLabel(iabSubCategory.trim()) : null
+  const iabTopCategoryId = iabTopCategory ? findKeyByLabel(iabTopCategory.trim()) : null
   return { ...syndicatedArticleBySlug, iabSubCategoryId, iabTopCategoryId }
 }
 

--- a/clients/web/src/containers/syndicated-article/syndicated-article.js
+++ b/clients/web/src/containers/syndicated-article/syndicated-article.js
@@ -97,7 +97,6 @@ export function SyndicatedArticle({ queryParams = validParams, locale }) {
   useEffect(() => {
     if (!showPlacards) return
 
-    console.info({ iabTopCategoryId, iabSubCategoryId })
     dispatch(
       getPlacards([
         {


### PR DESCRIPTION
## Goals

Added IAB reverse lookup for the ads team. All is well so long as an IAB cat and top cat exist.  If they do not, the trim was throwing an error.  Simple problem, simple fix.  No impact to ads as I am unclear if they are using it at the moment, but if they are it is in dev, so we can adjust to possible null values.

## To Do:

- [x] Check for value before looking up ID
