### PR TITLE
fix(annotations): merge overlap collisions

### DIFF
--- a/clients/web/src/components/annotations/utilities.js
+++ b/clients/web/src/components/annotations/utilities.js
@@ -1,104 +1,247 @@
 import DiffMatchPatch from 'diff-match-patch'
 
+// Set this to false if you do *not* want to merge overlapping highlights:
+const useMergedAnnotations = true
+
 // Flag to determine whether to use the diff-match-patch library
 const usePatch = true
 
+// If you just want to highlight *one* annotation:
 export function highlightAnnotation(annotation, onHover, element, callback) {
-  highlight(element, 'highlight', annotation, onHover, callback)
+  highlightAnnotations({ node: element, annotations: [annotation], annotationsCallback: callback })
 }
 
-// Main highlight function accepting an array of annotations
+/**
+ * highlightAnnotations
+ *  - The primary function: Takes a DOM node (or node ID) + an array of annotations,
+ *    finds matching text, optionally merges overlapping highlights, and applies them in a way
+ *    that supports multiple highlights within the same text node.
+ */
 export function highlightAnnotations({ node, annotations, annotationsCallback }) {
-  const tapListener = () => {}
-  const callback = () => {}
-
-  const className = 'highlight'
-  const doc = document
-
   if (!node) return
 
-  // Normalize node argument without mutation
-  const normalizedNode = normalizeNode(node, doc)
+  const normalizedNode = normalizeNode(node)
   if (!normalizedNode) return
 
-  // Collect text and index-node pairs without mutation
+  // Gather all text plus an "indices" array mapping absolute positions -> textNodes
   const { text, indices } = collectTextAndIndices(normalizedNode)
   if (!indices.length) return
 
-  // Combine text array into a single string
+  // Combine text into one big string
   const combinedText = text.join('')
-
-  // Add sentinel to indices immutably
+  // Add sentinel end position so we know where the last text node ends
   const updatedIndices = [...indices, { i: combinedText.length }]
 
-  // Collect all matches from all annotations
-  const allMatches = annotations
-    .map((annotation) => {
-      const match = findMatchingText(combinedText, annotation)
-      if (match) {
-        const { start, end } = calculateMatchIndices(match, combinedText)
-        return { start, end, annotation }
-      }
-      return null
-    })
-    .filter((match) => match !== null)
+  // For each annotation, figure out [start, end] in `combinedText`
+  let allMatches = []
+  for (const annotation of annotations) {
+    const found = findMatchingText(combinedText, annotation)
+    if (found) {
+      const { start, end } = calculateMatchIndices(found)
+      allMatches.push({ start, end, annotation })
+    }
+  }
+  if (!allMatches.length) return
 
-  if (allMatches.length === 0) return
+  // Sort the matches by start index
+  allMatches.sort((a, b) => a.start - b.start)
 
-  // Sort all matches by their start index
-  const sortedMatches = allMatches.sort((a, b) => a.start - b.start)
+  // Optionally merge overlapping matches (based on boolean flag)
+  if (useMergedAnnotations) {
+    allMatches = mergeOverlappingMatches(allMatches)
+  }
 
-  // Merge overlapping matches or handle conflicts as per requirements
-  const mergedMatches = mergeOverlappingMatches(sortedMatches)
-
-  // Apply all highlights to the DOM
-  applyHighlights({
+  // Apply highlights in a single pass *per text node*.
+  // This approach prevents issues if multiple highlights fall in the same node.
+  applyHighlightsSinglePass({
+    matches: allMatches,
     indices: updatedIndices,
-    matches: mergedMatches.reverse(),
-    className,
-    tapListener,
-    doc,
-    callback
+    className: 'highlight'
   })
 
   if (annotationsCallback) annotationsCallback()
 }
 
-// Helper Functions
-
 /**
- * Normalizes the node argument. If it's a string, treats it as an ID and retrieves the DOM node.
- * Returns a new reference without mutating the original input.
- * @param {Mixed} node - The DOM node or string ID.
- * @param {Document} doc - The document object.
- * @returns {Node|null} - The normalized DOM node or null if not found.
+ * applyHighlightsSinglePass
+ *  - We iterate over each text node in `indices`.
+ *  - We find all matches that intersect that text node’s range.
+ *  - We split that text node *one time*, creating highlight <span> elements as needed.
  */
-const normalizeNode = (node, doc) => {
-  return typeof node === 'string' ? doc.getElementById(node) : node
+function applyHighlightsSinglePass({ matches, indices, className }) {
+  // Loop through each text node. For i from 0..(indices.length - 2),
+  // each text node covers [indices[i].i .. indices[i+1].i).
+  for (let i = 0; i < indices.length - 1; i++) {
+    const nodeStart = indices[i].i
+    const nodeEnd = indices[i + 1].i
+    const textNode = indices[i].n
+    if (!textNode) continue
+
+    // Find all highlights that intersect [nodeStart, nodeEnd).
+    const relevant = []
+    for (const m of matches) {
+      if (m.end <= nodeStart) continue
+      if (m.start >= nodeEnd) continue
+      relevant.push(m)
+    }
+    if (!relevant.length) continue
+
+    // Slice up this text node in a single pass, building new pieces
+    highlightOneTextNode({
+      textNode,
+      nodeStart,
+      matches: relevant,
+      className
+    })
+  }
 }
 
 /**
- * Traverses the DOM tree to collect all text nodes and their corresponding indices.
- * Returns new arrays without mutating any existing data structures.
- * @param {Node} node - The root DOM node to traverse.
- * @returns {Object} - An object containing the concatenated text and indices array.
+ * highlightOneTextNode
+ *  - Given a single text node and all highlight ranges that intersect it,
+ *    break it into (text + highlight + text + highlight + ...).
  */
-const collectTextAndIndices = (node) => {
+function highlightOneTextNode({ textNode, nodeStart, matches, className }) {
+  const parent = textNode.parentNode
+  if (!parent) return
+
+  const originalText = textNode.nodeValue
+  const fragments = []
+  let currentPos = 0
+
+  // Because matches are sorted by start, we can iterate left to right
+  for (const m of matches) {
+    // Convert absolute positions [m.start, m.end] to relative positions within this text node
+    const startRel = Math.max(0, m.start - nodeStart)
+    const endRel = Math.min(originalText.length, m.end - nodeStart)
+
+    // If there's text before the highlight, push it
+    if (startRel > currentPos) {
+      fragments.push(document.createTextNode(originalText.substring(currentPos, startRel)))
+    }
+
+    // Then the highlighted part
+    if (endRel > startRel) {
+      const subText = originalText.substring(startRel, endRel)
+      const span = document.createElement('span')
+      span.className = className
+      span.textContent = subText
+
+      // This means sometimes the tap action of the sidebar will be non-functional (since we merged)
+      // away the annotation id ... for now this is acceptable.
+      const annotationId = m.annotation.annotation_id || m.annotation.id
+      if (annotationId) {
+        span.setAttribute('data-annotation-id', annotationId)
+      }
+
+      fragments.push(span)
+    }
+    currentPos = Math.max(currentPos, endRel)
+  }
+
+  // If there's leftover text after the last highlight
+  if (currentPos < originalText.length) {
+    fragments.push(document.createTextNode(originalText.substring(currentPos)))
+  }
+
+  // Replace the original text node with our new set of nodes
+  for (const f of fragments) {
+    parent.insertBefore(f, textNode)
+  }
+  parent.removeChild(textNode)
+}
+
+/**
+ * diff-match-patch or regex to locate the annotation’s text in the big string
+ */
+function findMatchingText(text, annotation) {
+  if ((annotation.version === 2 || annotation.version === '2') && usePatch) {
+    // Attempt patch
+    const dmp = new DiffMatchPatch()
+    const patch = dmp.patch_fromText(annotation.patch)
+    const [patchedText, results] = dmp.patch_apply(patch, text)
+    if (results[0]) {
+      // Found a place to apply the patch, see if we have <pkt_tag_annotation>...</pkt_tag_annotation>
+      const tagRegex = /<pkt_tag_annotation>([\s\S]+?)<\/pkt_tag_annotation>/
+      const execResult = tagRegex.exec(patchedText)
+      if (execResult && execResult[1] === annotation.quote) {
+        return execResult
+      }
+    }
+    // Removing second pass as it just convolutes things and creates more hearache. The merged
+    // annotations works more effectively and the fallback is a reasonable .. you know ... fallback
+  }
+
+  // fallback to regex matching the annotation’s exact quote
+  const regex = highlightRegex(annotation.quote.trim())
+  return regex.exec(text) // returns the first match or null
+}
+
+/**
+ * Convert the match object from RegExp.exec() into numeric start/end in the text
+ */
+function calculateMatchIndices(matchingText) {
+  if (!matchingText) return { start: 0, end: 0 }
+  let iTextStart = matchingText.index
+  // if we have capturing groups, decide if we only want group[1]
+  const whichGroup = matchingText.length > 1 ? 1 : 0
+  for (let i = 1; i < whichGroup; i++) {
+    iTextStart += matchingText[i].length
+  }
+  const iTextEnd = iTextStart + matchingText[whichGroup].length
+  return { start: iTextStart, end: iTextEnd }
+}
+
+/**
+ * Optionally merges overlapping matches into one.
+ * If you disable merging, you’ll see separate highlights if they overlap.
+ */
+function mergeOverlappingMatches(matches) {
+  if (!matches.length) return []
+  matches.sort((a, b) => a.start - b.start)
+
+  const merged = [matches[0]]
+  for (let i = 1; i < matches.length; i++) {
+    const last = merged[merged.length - 1]
+    const current = matches[i]
+
+    // If there's overlap
+    if (current.start <= last.end) {
+      // Merge the ranges
+      last.end = Math.max(last.end, current.end)
+    } else {
+      merged.push(current)
+    }
+  }
+  return merged
+}
+
+/**
+ * Turn a DOM node or string ID into a DOM node
+ */
+function normalizeNode(node) {
+  return typeof node === 'string' ? document.getElementById(node) : node
+}
+
+/**
+ * Recursively walk the DOM collecting all text nodes and their absolute positions.
+ */
+function collectTextAndIndices(root) {
   const indices = []
-  const stack = []
   const text = []
   let textLength = 0
 
-  let currentNode = node
+  const stack = []
+  let currentNode = root
   let iNode = 0
-  let nNodes = currentNode?.childNodes?.length
+  let nNodes = currentNode?.childNodes?.length || 0
 
-  if (!nNodes) return { indices, text }
+  if (!nNodes) return { text, indices }
 
-  // Cycle until we say stop
   while (true) {
     while (iNode < nNodes) {
       const child = currentNode.childNodes[iNode++]
+      if (!child) continue
 
       if (child.nodeType === Node.TEXT_NODE) {
         indices.push({ i: textLength, n: child })
@@ -106,8 +249,11 @@ const collectTextAndIndices = (node) => {
         text.push(nodeText)
         textLength += nodeText.length
       } else if (child.nodeType === Node.ELEMENT_NODE) {
-        if (/^(script|style)$/i.test(child.tagName)) continue
-
+        // skip <script> or <style>
+        if (/^(script|style)$/i.test(child.tagName)) {
+          continue
+        }
+        // Insert a space if it's a "blockish" element so that separate elements remain separated
         if (
           !/^(a|b|basefont|bdo|big|em|font|i|s|small|span|strike|strong|su[bp]|tt|u)$/i.test(
             child.tagName
@@ -127,231 +273,14 @@ const collectTextAndIndices = (node) => {
       }
     }
 
-    if (stack.length === 0) break
-
-    const state = stack.pop()
-    currentNode = state.node
-    nNodes = state.nNodes
-    iNode = state.iNode
+    if (!stack.length) break
+    const st = stack.pop()
+    currentNode = st.node
+    nNodes = st.nNodes
+    iNode = st.iNode
   }
 
   return { text, indices }
-}
-
-/**
- * Finds the matching text based on the annotation using diff-match-patch or regex.
- * Returns an object containing start and end indices if a match is found, else null.
- * @param {string} text - The combined text from the DOM.
- * @param {object} annotation - The annotation object containing patch or quote.
- * @returns {Object|null} - The match result with start and end indices or null.
- */
-const findMatchingText = (text, annotation) => {
-  let matchingText = null
-  if ((annotation.version === 2 || annotation.version === '2') && usePatch) {
-    const pktTagRegex = /<pkt_tag_annotation>([\s\S]*)<\/pkt_tag_annotation>/
-    const dmp = new DiffMatchPatch()
-    const patch = dmp.patch_fromText(annotation.patch)
-    const [patchedText, results] = dmp.patch_apply(patch, text)
-    if (results[0]) {
-      const execResult = pktTagRegex.exec(patchedText)
-      if (execResult && execResult[1] === annotation.quote) matchingText = execResult
-    } else {
-      // Deeper search with adjusted parameters
-      const newDmp = new DiffMatchPatch()
-      newDmp.Match_Distance = 1000
-      newDmp.Match_Threshold = 0.2
-      const secondPatch = newDmp.patch_fromText(annotation.patch)
-      const [secondPatchedText, secondResults] = newDmp.patch_apply(secondPatch, text)
-      if (secondResults[0]) {
-        const execResult = pktTagRegex.exec(secondPatchedText)
-        if (execResult) matchingText = execResult
-      }
-    }
-  }
-
-  if (!matchingText) {
-    // Fallback to regex matching the exact quote
-    const regex = highlightRegex(annotation.quote.trim())
-    const execResult = regex.exec(text)
-    if (execResult) matchingText = execResult
-  }
-
-  return matchingText
-}
-
-/**
- * Calculates the start and end indices of the match within the text.
- * @param {RegExpExecArray} matchingText - The regex match result.
- * @param {string} text - The combined text from the DOM.
- * @returns {Object} - An object containing start and end indices of the match.
- */
-const calculateMatchIndices = (matchingText) => {
-  if (!matchingText) return { start: 0, end: 0 }
-
-  let iTextStart = matchingText.index
-  const which = matchingText.length > 1 ? 1 : 0 // Adjust based on capturing groups
-  for (let i = 1; i < which; i++) {
-    iTextStart += matchingText[i].length
-  }
-  const iTextEnd = iTextStart + matchingText[which].length
-
-  return { start: iTextStart, end: iTextEnd }
-}
-
-/**
- * Merges overlapping matches to prevent conflicts.
- * You can customize the merging strategy as needed.
- * @param {Array} matches - Array of match objects with start, end, and annotation.
- * @returns {Array} - Array of merged match objects.
- */
-const mergeOverlappingMatches = (matches) => {
-  if (matches.length === 0) return []
-
-  // Sort matches by start index
-  const sorted = matches.sort((a, b) => a.start - b.start)
-
-  const merged = [sorted[0]]
-
-  for (let i = 1; i < sorted.length; i++) {
-    const last = merged[merged.length - 1]
-    const current = sorted[i]
-
-    if (current.start <= last.end) {
-      // Overlapping match found
-      // Decide on merging strategy:
-      // Here, we'll merge them and keep the earlier annotation
-      merged[merged.length - 1] = {
-        start: last.start,
-        end: Math.max(last.end, current.end),
-        annotation: last.annotation // Prioritize the first annotation
-      }
-    } else {
-      merged.push(current)
-    }
-  }
-
-  return merged
-}
-
-/**
- * Performs a binary search on the indices array to find the entry containing the start index.
- * Returns the index of the matching entry.
- * @param {Array} indices - The array of index-node pairs.
- * @param {number} iTextStart - The start index of the match.
- * @returns {number} - The index of the matching entry.
- */
-const binarySearchIndices = (indices, iTextStart) => {
-  let iLeft = 0
-  let iRight = indices.length
-
-  while (iLeft < iRight) {
-    const i = Math.floor((iLeft + iRight) / 2)
-    if (iTextStart < indices[i].i) {
-      iRight = i
-    } else if (iTextStart >= indices[i + 1]?.i) {
-      iLeft = i + 1
-    } else {
-      return i
-    }
-  }
-
-  return iLeft
-}
-
-/**
- * Applies all highlights to the DOM based on the matched indices.
- * Processes matches in order to prevent overlapping highlights.
- * @param {Object} params - Parameters required for applying highlights.
- */
-const applyHighlights = ({ indices, matches, className, tapListener, doc, callback }) => {
-  // To handle multiple highlights without interfering with each other,
-  // it's best to apply them from the end to the start of the text.
-  // This prevents earlier modifications from affecting the indices of later matches.
-
-  // Create a DocumentFragment to batch insertions
-  const insertionFragment = doc.createDocumentFragment()
-
-  // Iterate through matches in reverse order
-  for (let m = matches.length - 1; m >= 0; m--) {
-    const match = matches[m]
-    const { start, end, annotation } = match
-
-    // Find the starting and ending indices in the indices array
-    const startEntry = binarySearchIndices(indices, start)
-    const endEntry = binarySearchIndices(indices, end)
-
-    // Iterate through the relevant entries
-    for (let i = startEntry; i <= endEntry; i++) {
-      const entry = indices[i]
-      const node = entry.n
-      const nodeText = node.nodeValue
-      const parentNode = node.parentNode
-      const iNodeTextStart = start - entry.i
-      const iNodeTextEnd = end - entry.i
-
-      const textStart = iNodeTextStart > 0 ? nodeText.substring(0, iNodeTextStart) : null
-      const textMiddle = nodeText.substring(iNodeTextStart, iNodeTextEnd)
-      const textEnd = iNodeTextEnd < nodeText.length ? nodeText.substring(iNodeTextEnd) : null
-
-      // Create new nodes without mutating existing nodes
-      const newNodes = []
-
-      if (textStart) {
-        newNodes.push(doc.createTextNode(textStart))
-      }
-
-      const id = annotation.annotation_id || annotation.id
-      const newSpan = createHighlightSpan(doc, textMiddle, className, id, tapListener)
-      newNodes.push(newSpan)
-
-      if (textEnd) newNodes.push(doc.createTextNode(textEnd))
-
-      newNodes.forEach((newNode) => insertionFragment.appendChild(newNode))
-
-      // Replace the original node with the new nodes
-      parentNode.replaceChild(insertionFragment, node)
-    }
-  }
-
-  if (callback) callback()
-}
-
-/**
- * Creates a span element for the highlighted text without mutating any inputs.
- * @param {Document} doc - The document object.
- * @param {string} text - The text to highlight.
- * @param {string} className - The CSS class for highlighting.
- * @param {string|number} id - The annotation ID.
- * @param {function} tapListener - The event listener for interactions.
- * @returns {HTMLElement} - The created span element.
- */
-const createHighlightSpan = (doc, text, className, id, tapListener) => {
-  const span = doc.createElement('span')
-  span.setAttribute('annotation_id', id)
-  span.setAttribute('data-annotation-id', id)
-  span.className = className
-  span.textContent = text
-
-  if (tapListener) {
-    attachTapListeners(span, tapListener)
-  }
-
-  return span
-}
-
-/**
- * Attaches event listeners to the span for user interactions without mutating any external state.
- * @param {HTMLElement} element - The span element.
- * @param {function} tapListener - The event listener function.
- */
-const attachTapListeners = (element, tapListener) => {
-  try {
-    element.addEventListener('mouseover', tapListener, false)
-    element.addEventListener('mouseout', tapListener, false)
-    element.addEventListener('touchstart', tapListener, false)
-  } catch (e) {
-    console.warn(e)
-  }
 }
 
 /**
@@ -359,9 +288,8 @@ const attachTapListeners = (element, tapListener) => {
  * @param {string} quote - The exact text to match.
  * @returns {RegExp} - The constructed regex.
  */
-const highlightRegex = (quote) => {
-  const escapedQuote = escapeRegExp(quote)
-  return new RegExp(escapedQuote, 'g')
+function highlightRegex(quote) {
+  return new RegExp(escapeRegExp(quote), 'g')
 }
 
 /**
@@ -369,8 +297,8 @@ const highlightRegex = (quote) => {
  * @param {string} string - The string to escape.
  * @returns {string} - The escaped string.
  */
-const escapeRegExp = (string) => {
-  return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
+function escapeRegExp(str) {
+  return str.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
 }
 
 /**
@@ -380,40 +308,38 @@ const escapeRegExp = (string) => {
  * @return {Boolean}          Boolean that describes if remove was successfull
  */
 export function removeHighlight(element, className) {
-  // No element given just bail out
-  if (!element) {
-    return false
-  }
+  if (!element) return false
 
-  // Go through all elements recusively and remove all tags with the
-  // given className
   if (element.nodeType === 1) {
-    if (element.getAttribute('class') === className) {
-      const text = element.removeChild(element.firstChild)
-      element.parentNode.insertBefore(text, element)
+    if (element.classList && element.classList.contains(className)) {
+      const textContent = element.textContent
+      element.parentNode.insertBefore(document.createTextNode(textContent), element)
       element.parentNode.removeChild(element)
       return true
     }
 
-    let normalize = false
+    let normalizeNeeded = false
     const childNodesLength = element.childNodes.length
     for (let i = 0; i < childNodesLength; i++) {
-      if (removeHighlight(element.childNodes[i], className)) {
-        normalize = true
-      }
+      if (removeHighlight(element.childNodes[i], className)) normalizeNeeded = true
     }
-    if (normalize) {
-      element.normalize()
-    }
+    if (normalizeNeeded) element.normalize()
   }
 
   return false
 }
 
+/**
+ * Removes all highlights (with class "highlight") from the entire document
+ */
 export function removeAllHighlights() {
   removeHighlight(document.body, 'highlight')
 }
 
+/**
+ * Creates a patch using diff-match-patch, by wrapping the selected text in <tag_annotation> ... </tag_annotation>.
+ * This helps re-find that exact selection in a changed doc later.
+ */
 export function requestAnnotationPatch(sel) {
   const wholeThing = new Range()
   wholeThing.selectNodeContents(document.body)

--- a/clients/web/src/components/reader/sidebar.js
+++ b/clients/web/src/components/reader/sidebar.js
@@ -82,7 +82,9 @@ export const Sidebar = ({
 
   const handleAnnotationClick = (id) => {
     const highlight = document.querySelectorAll(`[data-annotation-id="${id}"]`)
-    highlight[0].scrollIntoView({ behavior: 'smooth', inline: 'nearest' })
+    const node = highlight[0]
+
+    if (node) node.scrollIntoView({ behavior: 'smooth', inline: 'nearest' })
   }
 
   return (


### PR DESCRIPTION
## Goals

Annotations was originally based on some very ancient code.  Modern code eventually outpaced it so a pseudo-rewrite happened, but it made overlaps behave oddly.  This is another patch to avoid needing to invest the effort for a proper, long term solution