### PR TITLE
fix(hydration): squash hydration warning in footer

### DIFF
--- a/clients/web/src/components/global-footer/global-footer.js
+++ b/clients/web/src/components/global-footer/global-footer.js
@@ -210,6 +210,7 @@ export const GlobalFooter = (props) => {
               </a>
               <button
                 onClick={oneTrustClickHandler}
+                suppressHydrationWarning
                 id="ot-sdk-btn"
                 className="ot-sdk-show-settings">
                 {t('global-footer:cookie-preferences', 'Cookie preferences')}


### PR DESCRIPTION
Cookie preferences has title case mismatch.  Just suppressing the warning given the nature of the repo